### PR TITLE
Incremental sync, HEVC transcode, and catalog commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,24 @@
 /migrate_csv_to_mongo.py
 /validation_results.csv
 /venv
+/.venv
+/.claude
+/nul
+
+# Artefactos generados por sync_dryrun.py
+/scan_manifest_dryrun.json
+/sync_report_dryrun.md
+/debug_course_page.html
+/debug_outline_*.html
+
+# Documentacion de diseno privada (vive en el repo privado del curador)
+/docs/superpowers/
+
+# Andamiaje de planificacion/orquestacion (solo local, nunca publico)
+/.superpowers/
+/.claude/
+*-brief.md
+*-report.md
+/staging/
+/sync_manifest.json
+/sync_report.md

--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ python kajabi.py
    - Press `Ctrl+C` again to resume
    - Press `Ctrl+C` twice quickly to exit
 
+## Incremental Sync
+
+Detecta lecciones nuevas/cambiadas/borradas frente a la ultima sincronizacion y
+descarga solo el delta a una carpeta de staging (no toca tu biblioteca curada).
+
+```bash
+# Ver que cambio sin descargar nada (escaneo estructural rapido):
+uv run python kajabi.py sync --dry-run
+
+# Acotar a un curso:
+uv run python kajabi.py sync --course armonia-avanzada --dry-run
+
+# Chequeo profundo (detecta videos resubidos con el mismo titulo; lento):
+uv run python kajabi.py sync --deep --course armonia-avanzada --dry-run
+
+# Descargar el delta a staging (pide confirmacion):
+uv run python kajabi.py sync
+
+# Solo escanear / solo comparar:
+uv run python kajabi.py scan
+uv run python kajabi.py diff
+```
+
+La primera corrida siembra la base desde `download_log.csv` (aproximada por titulo);
+a partir de la segunda, el diff es exacto por `post_id` y detecta tambien cambios y
+borrados. El comportamiento de descarga completa original se mantiene ejecutando
+`uv run python kajabi.py` sin subcomando.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ a partir de la segunda, el diff es exacto por `post_id` y detecta tambien cambio
 borrados. El comportamiento de descarga completa original se mantiene ejecutando
 `uv run python kajabi.py` sin subcomando.
 
+## Transcode to HEVC (optional)
+
+Re-encode downloaded videos to H.265/HEVC with ffmpeg to save space. Course-agnostic;
+requires `ffmpeg` on PATH. Picks the best available hardware encoder and falls back to CPU.
+
+```bash
+# Transcode a folder tree (mirrors structure into <input>_hevc, copies non-video through):
+uv run python kajabi.py transcode "path/to/course"
+
+# Choose encoder explicitly (auto-detects and falls back if unavailable):
+uv run python kajabi.py transcode "path/to/course" --encoder libx265 --crf 22
+
+# Preview without encoding:
+uv run python kajabi.py transcode "path/to/course" --dry-run
+
+# As part of a sync (transcode the freshly downloaded delta):
+uv run python kajabi.py sync --transcode
+```
+
+Flags: `--encoder auto|nvenc|qsv|amf|libx265`, `--crf`/`--cq`, `--preset`, `--tag`,
+`--res-tag`, `--no-copy-nonvideo`, `--embed-metadata`, `--replace`, `--jobs N`, `--dry-run`.
+Defaults live in `config.ini [Transcode]`.
+
+## Catalog / index
+
+Generate a JSON + CSV index of a downloaded course tree (course, block, track, title,
+kind, size, path). Course-agnostic; pure filesystem walk.
+
+```bash
+uv run python kajabi.py catalog "path/to/library" --json catalog.json --csv catalog.csv
+```
+
 ## Project Structure
 
 ```

--- a/config.ini
+++ b/config.ini
@@ -22,3 +22,9 @@ video_link = //a[contains(@href, ".mp4") and contains(@class, "sage-dropdown__it
 material_section = section.sage-sortable__item--card
 material_title = h1.sage-sortable__item-title
 material_link = a.sage-btn--icon-only-download
+
+[Sync]
+manifest_path = sync_manifest.json
+staging_dir = staging
+report_path = sync_report.md
+seed_csv = download_log.csv

--- a/config.ini
+++ b/config.ini
@@ -28,3 +28,12 @@ manifest_path = sync_manifest.json
 staging_dir = staging
 report_path = sync_report.md
 seed_csv = download_log.csv
+
+[Transcode]
+encoder = auto
+crf = 23
+cq = 28
+preset =
+tag = h265
+copy_nonvideo = true
+jobs = 1

--- a/kajabi.py
+++ b/kajabi.py
@@ -743,13 +743,41 @@ def _build_argparser():
         sp.add_argument("--yes", action="store_true")
 
     for name in ("scan", "diff", "sync"):
-        add_common(sub.add_parser(name))
+        sp = sub.add_parser(name)
+        add_common(sp)
+        if name == "sync":
+            sp.add_argument("--transcode", action="store_true")
+            sp.add_argument("--transcode-output", dest="transcode_output", default=None)
+
+    def tcfg(k, d):
+        return config.get("Transcode", k, fallback=d)
+    tp = sub.add_parser("transcode")
+    tp.add_argument("input", help="Carpeta raiz a transcodificar")
+    tp.add_argument("--output", default=None, help="Carpeta de salida (def: <input>_hevc)")
+    tp.add_argument("--encoder", default=tcfg("encoder", "auto"), help="auto|nvenc|qsv|amf|libx265")
+    tp.add_argument("--crf", type=int, default=config.getint("Transcode", "crf", fallback=23), help="Calidad CRF (libx265)")
+    tp.add_argument("--cq", type=int, default=config.getint("Transcode", "cq", fallback=28), help="Calidad CQ (hardware)")
+    tp.add_argument("--preset", default=tcfg("preset", ""), help="Preset del encoder")
+    tp.add_argument("--tag", default=tcfg("tag", "h265"), help="Tag en el nombre de salida")
+    tp.add_argument("--res-tag", dest="res_tag", action="store_true", help="Anadir resolucion al tag (h265_1080p)")
+    tp.add_argument("--copy-nonvideo", dest="copy_nonvideo", action="store_true",
+                    default=config.getboolean("Transcode", "copy_nonvideo", fallback=True), help="Copiar ficheros no-video")
+    tp.add_argument("--no-copy-nonvideo", dest="copy_nonvideo", action="store_false", help="No copiar no-video")
+    tp.add_argument("--embed-metadata", dest="embed_metadata", action="store_true", help="Embeber metadatos desde la ruta")
+    tp.add_argument("--replace", action="store_true", help="Borrar el original tras exito")
+    tp.add_argument("--jobs", type=int, default=config.getint("Transcode", "jobs", fallback=1), help="Transcodes en paralelo")
+    tp.add_argument("--dry-run", dest="dry_run", action="store_true", help="Solo mostrar el plan")
+
+    cp = sub.add_parser("catalog")
+    cp.add_argument("input", help="Carpeta raiz a catalogar")
+    cp.add_argument("--json", default="catalog.json", help="Ruta del indice JSON de salida")
+    cp.add_argument("--csv", default="catalog.csv", help="Ruta del indice CSV de salida")
     return p
 
 
 if __name__ == "__main__":
     _args = _build_argparser().parse_args()
-    if _args.command in ("scan", "diff", "sync"):
+    if _args.command in ("scan", "diff", "sync", "transcode", "catalog"):
         from kjsync import cli
         raise SystemExit(getattr(cli, f"cmd_{_args.command}")(_args))
     _run_full_download()

--- a/kajabi.py
+++ b/kajabi.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import requests
 import threading
@@ -19,6 +20,12 @@ from tqdm import tqdm
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 import traceback
 from datetime import datetime
+
+# Fix Windows console encoding for emojis and special characters
+if sys.platform == "win32":
+    import codecs
+    sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+    sys.stderr = codecs.getwriter("utf-8")(sys.stderr.detach())
 
 # Configuration
 config = configparser.ConfigParser()
@@ -152,79 +159,134 @@ def selenium_download_video(driver, lesson_url, video_path, video_filename, cour
         try:
             print(f"    ℹ️ Attempt {attempt + 1}/{MAX_RETRIES} to download video: {video_filename}")
             driver.get(lesson_url)
-            WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
             
+            # Esperar a que cargue el cuerpo y posibles iframes
+            WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+            time.sleep(3) # Pequeña espera extra para scripts JS
+
             # Check if on login page
             if "login" in driver.current_url:
                 print("    ⚠️ Session expired, re-logging in...")
                 driver.get(f"{KAJABI_URL}/login")
-                WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "username"))).send_keys(EMAIL)
-                driver.find_element(By.ID, "password").send_keys(PASSWORD)
+                WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "member_email"))).send_keys(EMAIL)
+                driver.find_element(By.ID, "member_password").send_keys(PASSWORD)
                 driver.find_element(By.XPATH, "//button[@type='submit']").click()
                 time.sleep(5)
                 driver.get(lesson_url)
                 WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
 
-            # Updated selector - more flexible
-            video_btn = WebDriverWait(driver, 30).until(
-                EC.element_to_be_clickable((By.XPATH, '//button[contains(., "Video Actions") or contains(., "video actions")]'))
-            )
-            driver.execute_script("arguments[0].scrollIntoView({behavior: 'smooth', block: 'center'});", video_btn)
-            time.sleep(1)
-            video_btn.click()
-            print("    🔽 Clicked 'Video Actions' button.")
-            
-            video_link_elem = WebDriverWait(driver, 30).until(
-                EC.presence_of_element_located((By.XPATH, '//a[contains(@href, ".mp4") and contains(@class, "sage-dropdown__item-control--icon-download")]'))
-            )
-            video_url = video_link_elem.get_attribute("href")
+            # --- NUEVA LÓGICA DE EXTRACCIÓN WISTIA ---
+            video_url = None
+            try:
+                import json
+                import re
+                
+                # Obtenemos todo el HTML de la página
+                page_source = driver.page_source
+                
+                # Lista de patrones para encontrar el ID de Wistia
+                # Tu HTML tiene el ID en la clase: wistia_async_glxqbp7vs5
+                wistia_patterns = [
+                    r'wistia_async_([a-z0-9]+)',          # Detecta: class="... wistia_async_ID ..."
+                    r'wistia\.com/medias/([a-z0-9]+)',    # Detecta: URL estándar
+                    r'embed/medias/([a-z0-9]+)\.',        # Detecta: src=".../embed/medias/ID.m3u8"
+                    r'wistia_embed\s+([^"\s]+)'           # Detecta: id="wistia_ID"
+                ]
 
-            download_dir = os.path.dirname(video_path)
-            driver.execute("send_command", {
-                'cmd': 'Page.setDownloadBehavior',
-                'params': {'behavior': 'allow', 'downloadPath': download_dir}
-            })
+                wistia_id = None
+                for pattern in wistia_patterns:
+                    match = re.search(pattern, page_source)
+                    if match:
+                        wistia_id = match.group(1)
+                        # Limpiar si el ID capturó algo extra por error (ej: wistia_glxqbp7vs5 -> glxqbp7vs5)
+                        if "wistia_" in wistia_id:
+                            wistia_id = wistia_id.replace("wistia_", "")
+                        print(f"    🎥 Found Wistia video ID: {wistia_id}")
+                        break
+                
+                if wistia_id:
+                    # Llamar a la API de Wistia para obtener el MP4 real
+                    wistia_api_url = f"https://fast.wistia.net/embed/medias/{wistia_id}.json"
+                    headers_api = {'Referer': lesson_url, 'User-Agent': 'Mozilla/5.0'} 
+                    response = requests.get(wistia_api_url, headers=headers_api)
+                    
+                    if response.status_code == 200:
+                        video_data = response.json()
+                        assets = video_data.get('media', {}).get('assets', [])
+                        
+                        # Filtrar solo archivos mp4 (evitar m3u8 o imágenes)
+                        mp4_assets = [
+                            a for a in assets 
+                            if (a.get('type') == 'original' or a.get('container') == 'mp4') 
+                            and a.get('type') != 'still_image'
+                        ]
+                        
+                        if mp4_assets:
+                            # Ordenar por tamaño de archivo (size) descendente para obtener la mejor calidad
+                            mp4_assets.sort(key=lambda x: x.get('size', 0), reverse=True)
+                            video_url = mp4_assets[0].get('url')
+                            # Asegurar que el enlace sea .bin o .mp4 y no .m3u8
+                            if video_url.endswith('.bin'):
+                                video_url = video_url.replace('.bin', '.mp4')
+                            
+                            print(f"    ✅ Extracted Wistia video URL (Quality: {mp4_assets[0].get('display_name')})")
+                    else:
+                        print(f"    ⚠️ Wistia API error: {response.status_code}")
 
-            driver.execute_script(f"window.open('{video_url}', '_blank');")
-            time.sleep(2)
-            driver.switch_to.window(driver.window_handles[-1])
+            except Exception as e:
+                print(f"    ⚠️ Error extracting Wistia video: {e}")
 
-            max_wait = 120
-            waited = 0
-            while not os.path.exists(video_path) and waited < max_wait:
-                time.sleep(1)
-                waited += 1
-                partial_files = [f for f in os.listdir(download_dir) if f.endswith('.crdownload') or f.startswith(os.path.splitext(video_filename)[0])]
-                if partial_files:
-                    print(f"    ℹ️ Download in progress: {partial_files[0]}")
+            # Fallback: Try traditional Kajabi video button if Wistia failed
+            if not video_url:
+                try:
+                    print("    Trying fallback 'Video Actions' button...")
+                    video_btn = WebDriverWait(driver, 5).until(
+                        EC.element_to_be_clickable((By.XPATH, '//button[contains(., "Video Actions") or contains(., "video actions")]'))
+                    )
+                    driver.execute_script("arguments[0].scrollIntoView({behavior: 'smooth', block: 'center'});", video_btn)
+                    time.sleep(1)
+                    video_btn.click()
+                    
+                    video_link_elem = WebDriverWait(driver, 5).until(
+                        EC.presence_of_element_located((By.XPATH, '//a[contains(@href, ".mp4") and contains(@class, "download")]'))
+                    )
+                    video_url = video_link_elem.get_attribute("href")
+                except Exception as e:
+                    pass # Fallback failed silently
+
+            if not video_url:
+                raise Exception("Could not find video URL via Wistia or Download Button")
+
+            # Download video using requests
+            print(f"    📥 Downloading video from URL...")
+            headers = {'User-Agent': 'Mozilla/5.0'}
+            with requests.get(video_url, stream=True, headers=headers, timeout=TIMEOUT) as r:
+                r.raise_for_status()
+                total_length = int(r.headers.get('content-length', 0))
+                progress = tqdm(total=total_length, unit='B', unit_scale=True, desc=video_filename, leave=False)
+                with open(video_path, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                            progress.update(len(chunk))
+                progress.close()
 
             if os.path.exists(video_path) and os.path.getsize(video_path) > 0:
                 print(f"    ✅ Downloaded video: {video_filename}")
                 status = get_lesson_status(course_title, module_title, lesson_title)
                 new_status = {"Description": status[0], "Thumbnail": status[1], "Video": "Success", "Material": status[3]}
                 log_status(course_title, module_title, lesson_title, new_status)
-                driver.close()
-                driver.switch_to.window(driver.window_handles[0])
                 return True
             else:
                 print(f"    ❌ Download failed: File not found or empty at {video_path}")
-                driver.close()
-                driver.switch_to.window(driver.window_handles[0])
                 raise Exception("Download incomplete")
         except TimeoutException as e:
-            print(f"    ❌ Timeout error on attempt {attempt + 1}/{MAX_RETRIES}: {e}")
-            with open("debug_log.txt", "a") as f:
-                f.write(f"Timeout in selenium_download_video: {driver.page_source[:1000]}\n")
+            print(f"    ❌ Timeout error on attempt {attempt + 1}/{MAX_RETRIES}")
             if attempt < MAX_RETRIES - 1:
                 time.sleep(5)
                 driver.refresh()
         except Exception as e:
             print(f"    ❌ Error downloading video {video_filename}: {e}")
-            with open("debug_log.txt", "a") as f:
-                traceback.print_exc(file=f)
-            if len(driver.window_handles) > 1:
-                driver.close()
-                driver.switch_to.window(driver.window_handles[0])
             if attempt < MAX_RETRIES - 1:
                 time.sleep(5)
                 driver.refresh()
@@ -249,40 +311,65 @@ def login_to_kajabi():
     DRIVER.get(f"{KAJABI_URL}/login")
 
     try:
-        WebDriverWait(DRIVER, 30).until(EC.presence_of_element_located((By.ID, "username"))).send_keys(EMAIL)
-        DRIVER.find_element(By.ID, "password").send_keys(PASSWORD)
+        WebDriverWait(DRIVER, 30).until(EC.presence_of_element_located((By.ID, "member_email"))).send_keys(EMAIL)
+        DRIVER.find_element(By.ID, "member_password").send_keys(PASSWORD)
         DRIVER.find_element(By.XPATH, "//button[@type='submit']").click()
         time.sleep(5)
-        if "dashboard" in DRIVER.current_url or "admin" in DRIVER.current_url:
-            print("✅ Logged into Kajabi successfully!")
+        if "library" in DRIVER.current_url or "dashboard" in DRIVER.current_url or "admin" in DRIVER.current_url:
+            print("Logged into Kajabi successfully!")
             return DRIVER
         else:
-            print("❌ Login failed. Check credentials or 2FA.")
+            print("Login failed. Check credentials or 2FA.")
             DRIVER.quit()
             return None
     except Exception as e:
-        print(f"❌ Login error: {e}")
+        print(f"Login error: {e}")
+        with open("debug_log.txt", "a", encoding="utf-8") as f:
+            traceback.print_exc(file=f)
         DRIVER.quit()
         return None
 
 def get_all_courses(driver):
-    print("🔍 Navigating to courses page...")
-    driver.get("https://app.kajabi.com/admin/sites/100181/courses")
+    print("Navigating to library page...")
+    driver.get(f"{KAJABI_URL}/library")
     time.sleep(5)
 
-    course_cards = driver.find_elements(By.CSS_SELECTOR, "li.sage-catalog-item")
+    # Use Kajabi student library selectors
+    course_cards = driver.find_elements(By.CSS_SELECTOR, "div.product")
+
+    if not course_cards:
+        print("Could not find courses. Saving page source for debugging...")
+        with open("debug_library_page.html", "w", encoding="utf-8") as f:
+            f.write(driver.page_source)
+        print("Page source saved to debug_library_page.html")
+        return []
+
+    print(f"Found {len(course_cards)} products in library")
+
     courses = []
     for card in course_cards:
         try:
-            title_elem = card.find_element(By.CSS_SELECTOR, "span.t-sage--truncate")
-            link_elem = card.find_element(By.CSS_SELECTOR, "a.sage-link")
+            title_elem = card.find_element(By.CSS_SELECTOR, "h4.product__title")
             title = title_elem.text.strip()
-            url = link_elem.get_attribute("href")
 
-            print(f"🟢 Found course: {title}")
+            # Get the link - try to find any link first
+            try:
+                link_elem = card.find_element(By.CSS_SELECTOR, "a[href*='/products/']")
+                url = link_elem.get_attribute("href")
+            except:
+                # Might be a community or other item, skip it
+                print(f"Skipping non-course item: {title}")
+                continue
+
+            # Double-check: Skip community/non-course items
+            if "/communities/" in url:
+                print(f"Skipping community item: {title}")
+                continue
+
+            print(f"Found course: {title}")
             courses.append({
                 "title": title,
-                "url": "https://app.kajabi.com" + url if url.startswith("/") else url
+                "url": url if url.startswith("http") else f"{KAJABI_URL}{url}"
             })
 
             safe_title = "".join(c if c.isalnum() or c in " _-–" else "_" for c in title)[:200]
@@ -290,8 +377,8 @@ def get_all_courses(driver):
             os.makedirs(course_path, exist_ok=True)
 
         except Exception as e:
-            print(f"⚠️ Error reading course card: {e}")
-            with open("debug_log.txt", "a") as f:
+            print(f"Error reading course card: {e}")
+            with open("debug_log.txt", "a", encoding="utf-8") as f:
                 traceback.print_exc(file=f)
 
     return courses
@@ -317,7 +404,7 @@ def download_file_safe(url, local_path, label=None):
             time.sleep(3)
         except Exception as e:
             print(f"    ❌ Download error {label}: {e}. Attempt {attempt + 1}/{MAX_RETRIES}")
-            with open("debug_log.txt", "a") as f:
+            with open("debug_log.txt", "a", encoding="utf-8") as f:
                 traceback.print_exc(file=f)
             time.sleep(3)
     FAILED_DOWNLOADS.append({"file": label, "url": url, "error": "Max retries exceeded"})
@@ -490,112 +577,179 @@ def process_lesson(driver, lesson_url, lesson_title, lesson_path, lesson_counter
     log_status(course_title, module_title, safe_lesson_base, status)
 
 def get_modules_and_lessons(driver, course_url, course_folder, course_title):
-    print(f"\n📘 Scraping modules + lessons from course: {course_url}")
+    print(f"\nScraping modules + lessons from course: {course_url}")
     for attempt in range(MAX_RETRIES):
         try:
             driver.get(course_url)
             WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
             time.sleep(4)
 
-            try:
-                expand_btn = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.XPATH, '//button[.//span[contains(text(), "Expand All")]]')))
-                expand_btn.click()
-                print("    🔼 Clicked 'Expand All' button.")
-                time.sleep(2)
-            except:
-                print("    ℹ️ 'Expand All' button not found.")
-
+            # Student interface uses different structure
             lessons = []
-            current_module_title = None
-            module_path = None
             module_counter = 1
             lesson_counter = 1
-
             completed_lessons = get_completed_lessons()
 
-            outline_items = WebDriverWait(driver, 30).until(
-                EC.presence_of_all_elements_located((By.CSS_SELECTOR, 'section.kjb-outlinelist-item'))
-            )
-            for index, item in enumerate(outline_items):
-                class_name = item.get_attribute("class")
+            # Find all module categories (h3.product-outline-category)
+            category_headers = driver.find_elements(By.CSS_SELECTOR, 'h3.product-outline-category')
 
-                if "kjb-outlinelist-item--category" in class_name:
-                    current_module_title = item.find_element(By.CSS_SELECTOR, 'span.sage-btn__truncate-text').text.strip()
+            if not category_headers:
+                print("Could not find any modules. Saving page source for debugging...")
+                with open("debug_course_page.html", "w", encoding="utf-8") as f:
+                    f.write(driver.page_source)
+                print("Page source saved to debug_course_page.html")
+                return
+
+            print(f"Found {len(category_headers)} modules")
+
+            for category_header in category_headers:
+                try:
+                    # Extract module title - try multiple selectors
+                    try:
+                        module_title_elem = category_header.find_element(By.CSS_SELECTOR, 'div.media-body a')
+                        current_module_title = module_title_elem.text.strip()
+                    except NoSuchElementException:
+                        # Fallback: try getting text from the entire category header
+                        try:
+                            current_module_title = category_header.text.strip().split('\n')[0]
+                        except:
+                            print("    ⚠️ Could not extract module title, skipping...")
+                            continue
+
+                    # Skip empty titles
+                    if not current_module_title:
+                        continue
+
                     module_folder_name = f"{module_counter:02d} - {current_module_title}"
                     safe_module = "".join(c if c.isalnum() or c in " _-–" else "_" for c in module_folder_name)[:200]
                     module_path = os.path.join(course_folder, safe_module)
                     os.makedirs(module_path, exist_ok=True)
-                    print(f"\n📂 Module: {module_folder_name}")
+                    print(f"\nModule: {module_folder_name}")
+
+                    # Get the data-target to find corresponding lessons
+                    data_target = category_header.get_attribute('data-target')
+                    if data_target:
+                        category_id = data_target.replace('#', '')
+
+                        # Find all lesson links within this category
+                        lesson_links = driver.find_elements(By.CSS_SELECTOR, f'div#{category_id} a.product-outline-post')
+
+                        lesson_counter = 1
+                        for lesson_link in lesson_links:
+                            try:
+                                lesson_url = lesson_link.get_attribute('href')
+                                lesson_title_elem = lesson_link.find_element(By.CSS_SELECTOR, 'div.media-body')
+                                lesson_title = lesson_title_elem.text.strip()
+
+                                # Skip empty titles
+                                if not lesson_title or not lesson_url:
+                                    continue
+
+                                safe_lesson_base = f"{lesson_counter:02d} - {lesson_title}"
+                                safe_lesson_base = "".join(c if c.isalnum() or c in " _-–" else "_" for c in safe_lesson_base)[:200]
+                                lesson_key = f"{course_title}|{current_module_title}|{safe_lesson_base}"
+
+                                desc_status, thumb_status, video_status, mat_status = get_lesson_status(course_title, current_module_title, safe_lesson_base)
+                                if lesson_key in completed_lessons and all(s in ["Success", "None"] for s in [desc_status, thumb_status, video_status, mat_status]):
+                                    print(f"    Already downloaded. Skipping lesson: {safe_lesson_base}")
+                                    lesson_counter += 1
+                                    continue
+
+                                print(f"  Lesson: {safe_lesson_base}")
+                                lesson_path = os.path.join(module_path, safe_lesson_base)
+                                os.makedirs(lesson_path, exist_ok=True)
+                                lessons.append((lesson_url, lesson_title, lesson_path, lesson_counter, safe_lesson_base, current_module_title))
+                                lesson_counter += 1
+
+                            except Exception as e:
+                                print(f"    Error processing lesson: {e}")
+                                continue
+
                     module_counter += 1
-                    lesson_counter = 1
 
-                elif "kjb-outlinelist-item--depth-1" in class_name and module_path:
-                    lesson_title = item.find_element(By.CSS_SELECTOR, 'span.sage-btn__truncate-text').text.strip()
-                    lesson_link = item.find_element(By.CSS_SELECTOR, 'a[href*="/admin/posts/"]').get_attribute("href")
-                    safe_lesson_base = f"{lesson_counter:02d} - {lesson_title}"
-                    safe_lesson_base = "".join(c if c.isalnum() or c in " _-–" else "_" for c in safe_lesson_base)[:200]
-                    lesson_key = f"{course_title}|{current_module_title}|{safe_lesson_base}"
+                except Exception as e:
+                    print(f"Error processing module: {e}")
+                    continue
 
-                    desc_status, thumb_status, video_status, mat_status = get_lesson_status(course_title, current_module_title, safe_lesson_base)
-                    if lesson_key in completed_lessons and all(s in ["Success", "None"] for s in [desc_status, thumb_status, video_status, mat_status]):
-                        print(f"    ⏭️ Already downloaded. Skipping lesson: {safe_lesson_base}")
-                        lesson_counter += 1
-                        continue
+            print(f"\nTotal lessons to download: {len(lessons)}")
 
-                    print(f"  🎓 Lesson: {safe_lesson_base}")
-                    lesson_path = os.path.join(module_path, safe_lesson_base)
-                    os.makedirs(lesson_path, exist_ok=True)
-                    lessons.append((lesson_link, lesson_title, lesson_path, lesson_counter, safe_lesson_base, current_module_title))
-                    lesson_counter += 1
+            # Process lessons sequentially (not in parallel) to avoid conflicts with Selenium
+            for lesson_data in lessons:
+                process_lesson(driver, lesson_data[0], lesson_data[1], lesson_data[2], lesson_data[3], lesson_data[4], course_title, lesson_data[5])
 
-            with ThreadPoolExecutor(max_workers=MAX_LESSON_THREADS) as executor:
-                executor.map(lambda args: process_lesson(driver, args[0], args[1], args[2], args[3], args[4], course_title, args[5]), lessons)
             return
 
         except TimeoutException as e:
-            print(f"    ❌ Timeout error on attempt {attempt + 1}/{MAX_RETRIES}: {e}")
-            with open("debug_log.txt", "a") as f:
+            print(f"    Timeout error on attempt {attempt + 1}/{MAX_RETRIES}: {e}")
+            with open("debug_log.txt", "a", encoding="utf-8") as f:
                 f.write(f"Timeout in get_modules_and_lessons: {driver.page_source[:1000]}\n")
             if attempt < MAX_RETRIES - 1:
                 time.sleep(5)
                 driver.refresh()
         except Exception as e:
-            print(f"    ⚠️ Error parsing course: {e}")
-            with open("debug_log.txt", "a") as f:
+            print(f"    Error parsing course: {e}")
+            with open("debug_log.txt", "a", encoding="utf-8") as f:
                 traceback.print_exc(file=f)
             if attempt < MAX_RETRIES - 1:
                 time.sleep(5)
                 driver.refresh()
-    print(f"    ❌ Failed to scrape course after {MAX_RETRIES} attempts.")
+    print(f"    Failed to scrape course after {MAX_RETRIES} attempts.")
     FAILED_DOWNLOADS.append({"file": course_title, "url": course_url, "error": "Failed to scrape modules"})
 
-if __name__ == "__main__":
+def _run_full_download():
     start_time = time.time()
-
     driver = login_to_kajabi()
     if driver:
         courses = get_all_courses(driver)
-        print(f"\n📘 Found {len(courses)} courses.")
-
+        print(f"\nFound {len(courses)} courses.")
         for course in courses:
             course_title = course["title"]
             course_url = course["url"]
-            safe_course = "".join(c if c.isalnum() or c in " _-–" else "_" for c in course_title)[:200]
+            safe_course = "".join(c if c.isalnum() or c in " _-" else "_" for c in course_title)[:200]
             course_folder = os.path.join(BASE_DIR, safe_course)
             os.makedirs(course_folder, exist_ok=True)
-
-            print(f"\n🚀 Processing course: {course_title}")
+            print(f"\n==> Processing course: {course_title}")
             get_modules_and_lessons(driver, course_url, course_folder, course_title)
-
         driver.quit()
-
-    end_time = time.time()
-    print(f"\n⏱️ Total time: {round(end_time - start_time, 2)} seconds")
-
+    print(f"\nTotal time: {round(time.time() - start_time, 2)} seconds")
     if FAILED_DOWNLOADS:
         with open("download_errors.txt", "w", encoding="utf-8") as f:
             for fail in FAILED_DOWNLOADS:
                 f.write(f"[FAILED] {fail.get('file', fail.get('title'))}\nURL: {fail['url']}\nError: {fail['error']}\n\n")
-        print(f"\n⚠️ Some downloads failed. Logged in 'download_errors.txt'")
+        print("\nSome downloads failed. Logged in 'download_errors.txt'")
     else:
-        print("\n✅ All downloads completed without errors.")
+        print("\nAll downloads completed without errors.")
+
+
+def _build_argparser():
+    import argparse
+    cfg_manifest = config.get("Sync", "manifest_path", fallback="sync_manifest.json")
+    cfg_staging = config.get("Sync", "staging_dir", fallback="staging")
+    cfg_report = config.get("Sync", "report_path", fallback="sync_report.md")
+    cfg_seed = config.get("Sync", "seed_csv", fallback="download_log.csv")
+
+    p = argparse.ArgumentParser(description="Descargador y sincronizador de cursos Kajabi")
+    sub = p.add_subparsers(dest="command")
+
+    def add_common(sp):
+        sp.add_argument("--manifest", default=cfg_manifest)
+        sp.add_argument("--report", default=cfg_report)
+        sp.add_argument("--staging-dir", dest="staging_dir", default=cfg_staging)
+        sp.add_argument("--seed-csv", dest="seed_csv", default=cfg_seed)
+        sp.add_argument("--course", action="append", default=[])
+        sp.add_argument("--deep", action="store_true")
+        sp.add_argument("--headless", action="store_true")
+        sp.add_argument("--dry-run", dest="dry_run", action="store_true")
+        sp.add_argument("--yes", action="store_true")
+
+    for name in ("scan", "diff", "sync"):
+        add_common(sub.add_parser(name))
+    return p
+
+
+if __name__ == "__main__":
+    _args = _build_argparser().parse_args()
+    if _args.command in ("scan", "diff", "sync"):
+        from kjsync import cli
+        raise SystemExit(getattr(cli, f"cmd_{_args.command}")(_args))
+    _run_full_download()

--- a/kjsync/__init__.py
+++ b/kjsync/__init__.py
@@ -1,0 +1,1 @@
+"""Motor de sincronizacion incremental para descargas de Kajabi (agnostico al curso)."""

--- a/kjsync/browser.py
+++ b/kjsync/browser.py
@@ -1,0 +1,37 @@
+"""Construccion del driver y login (Selenium). Productivizado de sync_dryrun.py."""
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from webdriver_manager.chrome import ChromeDriverManager
+
+
+def build_driver(headless=False, base_dir="."):
+    options = Options()
+    if headless:
+        options.add_argument("--headless=new")
+    options.add_argument("--start-maximized")
+    options.add_experimental_option("prefs", {
+        "profile.default_content_setting_values.notifications": 2,
+        "download.default_directory": base_dir,
+        "download.prompt_for_download": False,
+    })
+    return webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+
+
+def login(driver, base_url, email, password):
+    base_url = base_url.rstrip("/")
+    driver.get(f"{base_url}/login")
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.ID, "member_email"))).send_keys(email)
+    driver.find_element(By.ID, "member_password").send_keys(password)
+    driver.find_element(By.XPATH, "//button[@type='submit']").click()
+    time.sleep(6)
+    if "login" not in driver.current_url:
+        return True
+    # Posible 2FA/captcha: dar margen a resolverlo en la ventana
+    time.sleep(20)
+    return "login" not in driver.current_url

--- a/kjsync/catalog.py
+++ b/kjsync/catalog.py
@@ -1,0 +1,68 @@
+"""Catalogo/indice generico de un arbol de curso descargado (agnostico al curso)."""
+import os
+import csv
+import json
+
+from kjsync import transcode
+
+MATERIAL_EXTS = {".pdf", ".zip", ".docx", ".pptx", ".xlsx", ".srt", ".txt", ".mp3", ".wav"}
+
+
+def classify_kind(ext):
+    e = (ext or "").lower()
+    if e in transcode.VIDEO_EXTS:
+        return "video"
+    if e in MATERIAL_EXTS:
+        return "material"
+    return "other"
+
+
+def catalog_entry(rel_path, size):
+    meta = transcode.parse_path_metadata(rel_path)
+    ext = os.path.splitext(rel_path)[1].lower()
+    return {
+        "course": meta["course"],
+        "block": meta["block"],
+        "track": meta["track"],
+        "title": meta["title"],
+        "relative_path": rel_path,
+        "ext": ext,
+        "kind": classify_kind(ext),
+        "size": size,
+    }
+
+
+def build_catalog(root):
+    entries = []
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            full = os.path.join(dirpath, f)
+            rel = os.path.relpath(full, root).replace(os.sep, "/")
+            try:
+                size = os.path.getsize(full)
+            except OSError:
+                size = 0
+            entries.append(catalog_entry(rel, size))
+    entries.sort(key=lambda e: e["relative_path"])
+    return entries
+
+
+_FIELDS = ["course", "block", "track", "title", "kind", "ext", "size", "relative_path"]
+
+
+def write_json(entries, path):
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"generated_count": len(entries), "entries": entries}, f,
+                  ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+def write_csv(entries, path):
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=_FIELDS)
+        w.writeheader()
+        for e in entries:
+            w.writerow({k: e.get(k, "") for k in _FIELDS})
+    os.replace(tmp, path)

--- a/kjsync/cli.py
+++ b/kjsync/cli.py
@@ -1,0 +1,163 @@
+"""Comandos scan / diff / sync (orquestacion del motor)."""
+import os
+from datetime import datetime, timezone
+from dotenv import load_dotenv
+
+from kjsync import browser, scan, diff as diffmod, report as reportmod, model, seed
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _env():
+    load_dotenv()
+    return (os.getenv("KAJABI_EMAIL"), os.getenv("KAJABI_PASSWORD"),
+            (os.getenv("KAJABI_URL") or "").rstrip("/"))
+
+
+def _scan_to_manifest(args):
+    email, password, base = _env()
+    driver = browser.build_driver(headless=args.headless)
+    try:
+        if not browser.login(driver, base, email, password):
+            print("ERROR: login fallido")
+            return None
+        course_filter = args.course or None
+        return scan.scan_library(driver, base, _now(), course_filter=course_filter, deep=args.deep)
+    finally:
+        driver.quit()
+
+
+def cmd_scan(args):
+    manifest = _scan_to_manifest(args)
+    if manifest is None:
+        return 1
+    model.save_manifest(manifest, args.manifest)
+    print(f"Manifiesto escrito en {args.manifest}")
+    return 0
+
+
+def cmd_diff(args):
+    new = model.load_manifest(args.manifest)
+    if new is None:
+        print(f"ERROR: no existe {args.manifest}; corre 'scan' primero")
+        return 1
+    # Para 'diff' suelto comparamos el manifiesto guardado contra la base sembrada
+    baseline = seed.seed_manifest_from_csv(args.seed_csv, _now()) if os.path.exists(args.seed_csv) else model.new_manifest(_now())
+    result = diffmod.diff_manifests(baseline, new)
+    md = reportmod.render_report(result, new.get("scanned_at", ""), args.deep)
+    with open(args.report, "w", encoding="utf-8") as f:
+        f.write(md)
+    print(md)
+    return 0
+
+
+def _seed_or_empty(args):
+    if args.seed_csv and os.path.exists(args.seed_csv):
+        print(f"Sin manifiesto previo; sembrando base desde {args.seed_csv}")
+        return seed.seed_manifest_from_csv(args.seed_csv, _now())
+    return model.new_manifest(_now())
+
+
+def _restrict_to_scanned_courses(baseline, scanned):
+    """Para sync acotado (--course): limita la base a los cursos escaneados
+    (casando por slug o por titulo normalizado) para no reportar como borrados
+    los cursos no escaneados."""
+    from kjsync.extract import norm
+    scanned_slugs = set(scanned.get("courses", {}).keys())
+    scanned_titles = {norm(c.get("title", "")) for c in scanned.get("courses", {}).values()}
+    out = model.new_manifest(baseline.get("scanned_at", ""))
+    for slug, course in baseline.get("courses", {}).items():
+        if slug in scanned_slugs or norm(course.get("title", "")) in scanned_titles:
+            out["courses"][slug] = course
+    return out
+
+
+def _merge_scanned_into_prior(prior, scanned):
+    """Funde los cursos escaneados sobre el manifiesto previo (sin perder los
+    cursos no escaneados); casa por slug."""
+    merged = {"scanned_at": scanned.get("scanned_at", ""),
+              "courses": dict(prior.get("courses", {}))}
+    for slug, course in scanned.get("courses", {}).items():
+        merged["courses"][slug] = course
+    return merged
+
+
+def _drop_lessons(manifest, post_ids):
+    """Elimina del manifiesto las lecciones con esos post_id (descargas fallidas),
+    para que reaparezcan como delta en la proxima sync."""
+    for course in manifest.get("courses", {}).values():
+        for moduleobj in course.get("modules", {}).values():
+            doomed = [k for k, l in list(moduleobj.get("lessons", {}).items())
+                      if l.get("post_id") in post_ids]
+            for k in doomed:
+                del moduleobj["lessons"][k]
+
+
+def cmd_sync(args):
+    prior_file = model.load_manifest(args.manifest)
+    baseline = prior_file if prior_file is not None else _seed_or_empty(args)
+    new = _scan_to_manifest(args)
+    if new is None:
+        return 1
+
+    diff_baseline = baseline
+    if args.course:
+        diff_baseline = _restrict_to_scanned_courses(baseline, new)
+
+    result = diffmod.diff_manifests(diff_baseline, new)
+    md = reportmod.render_report(result, new.get("scanned_at", ""), args.deep)
+    with open(args.report, "w", encoding="utf-8") as f:
+        f.write(md)
+    print(md)
+    print(f"\nInforme escrito en {args.report}")
+
+    to_download = []
+    for b in result["courses"].values():
+        to_download.extend(b["new"])
+        to_download.extend(b["changed"])
+    print(f"\nA descargar (nuevo + cambiado): {len(to_download)} lecciones")
+
+    if args.dry_run:
+        print("--dry-run: no se descarga nada. (Manifiesto NO actualizado.)")
+        return 0
+    if not args.yes and to_download:
+        resp = input("Proceder con la descarga? [s/N] ").strip().lower()
+        if resp not in ("s", "si", "y", "yes"):
+            print("Cancelado. (Manifiesto NO actualizado.)")
+            return 0
+
+    failed_pids = set()
+    if to_download:
+        from kjsync import download
+        email, password, base = _env()
+        driver = browser.build_driver(headless=args.headless)
+        try:
+            if not browser.login(driver, base, email, password):
+                print("ERROR: login fallido; no se descarga el delta. Manifiesto NO actualizado.")
+                return 1
+            new_by_pid = {r["post_id"]: r for r in model.iter_lessons(new) if r["post_id"]}
+            for ref in to_download:
+                full = new_by_pid.get(ref["post_id"], ref)
+                lesson = {"order": full.get("order", 1), "title": full["title"], "url": full["url"]}
+                safe_mod = "".join(c if c.isalnum() or c in " ._-" else "_" for c in ref["module_title"])[:200]
+                dest = os.path.join(args.staging_dir, ref["course_slug"], safe_mod)
+                print(f"  -> {ref['course_slug']} / {ref['title']}")
+                status = download.download_lesson(driver, lesson, dest)
+                if status.get("video") == "Failed" or status.get("materials") == "Failed":
+                    failed_pids.add(ref["post_id"])
+                    print(f"     AVISO: descarga incompleta, se reintentara en la proxima sync: {ref['title']}")
+        finally:
+            driver.quit()
+
+    if failed_pids:
+        _drop_lessons(new, failed_pids)
+
+    if prior_file is not None and args.course:
+        to_save = _merge_scanned_into_prior(prior_file, new)
+    else:
+        to_save = new
+    model.save_manifest(to_save, args.manifest)
+    print(f"Manifiesto actualizado en {args.manifest}")
+    return 0

--- a/kjsync/cli.py
+++ b/kjsync/cli.py
@@ -44,13 +44,30 @@ def cmd_diff(args):
         print(f"ERROR: no existe {args.manifest}; corre 'scan' primero")
         return 1
     # Para 'diff' suelto comparamos el manifiesto guardado contra la base sembrada
-    baseline = seed.seed_manifest_from_csv(args.seed_csv, _now()) if os.path.exists(args.seed_csv) else model.new_manifest(_now())
+    baseline = seed.seed_manifest_from_csv(args.seed_csv, _now()) if args.seed_csv and os.path.exists(args.seed_csv) else model.new_manifest(_now())
     result = diffmod.diff_manifests(baseline, new)
     md = reportmod.render_report(result, new.get("scanned_at", ""), args.deep)
     with open(args.report, "w", encoding="utf-8") as f:
         f.write(md)
     print(md)
     return 0
+
+
+def _transcode_config():
+    import configparser
+    c = configparser.ConfigParser()
+    c.read("config.ini")
+    if not c.has_section("Transcode"):
+        return {}
+    return {
+        "encoder": c.get("Transcode", "encoder", fallback="auto"),
+        "crf": c.getint("Transcode", "crf", fallback=23),
+        "cq": c.getint("Transcode", "cq", fallback=28),
+        "preset": c.get("Transcode", "preset", fallback="") or None,
+        "tag": c.get("Transcode", "tag", fallback="h265"),
+        "copy_nonvideo": c.getboolean("Transcode", "copy_nonvideo", fallback=True),
+        "jobs": c.getint("Transcode", "jobs", fallback=1),
+    }
 
 
 def _seed_or_empty(args):
@@ -154,10 +171,48 @@ def cmd_sync(args):
     if failed_pids:
         _drop_lessons(new, failed_pids)
 
+    if getattr(args, "transcode", False) and not args.dry_run and to_download:
+        from kjsync import transcode as tc
+        if tc.is_ffmpeg_available():
+            out = args.transcode_output or (args.staging_dir.rstrip("/\\") + "_hevc")
+            print(f"\nTranscodificando staging -> {out}")
+            tc.transcode_tree(args.staging_dir, out, progress=print, **_transcode_config())
+        else:
+            print("AVISO: --transcode pedido pero ffmpeg no esta disponible; se omite.")
+
     if prior_file is not None and args.course:
         to_save = _merge_scanned_into_prior(prior_file, new)
     else:
         to_save = new
     model.save_manifest(to_save, args.manifest)
     print(f"Manifiesto actualizado en {args.manifest}")
+    return 0
+
+
+def cmd_transcode(args):
+    from kjsync import transcode
+    out = args.output or (args.input.rstrip("/\\") + "_hevc")
+    summary = transcode.transcode_tree(
+        args.input, out, encoder=args.encoder, crf=args.crf, cq=args.cq,
+        preset=(args.preset or None), tag=args.tag, res_tag=args.res_tag,
+        copy_nonvideo=args.copy_nonvideo, embed_metadata=args.embed_metadata,
+        replace=args.replace, jobs=args.jobs, dry_run=args.dry_run)
+    if summary.get("error"):
+        return 1
+    print(f"\nResumen: {summary['transcoded']} transcodificados, {summary['copied']} copiados, "
+          f"{summary['skipped']} saltados, {len(summary['failed'])} fallidos -> {out}")
+    return 1 if summary["failed"] else 0
+
+
+def cmd_catalog(args):
+    import os
+    from kjsync import catalog
+    if not os.path.isdir(args.input):
+        print(f"ERROR: no existe la carpeta: {args.input}")
+        return 1
+    entries = catalog.build_catalog(args.input)
+    catalog.write_json(entries, args.json)
+    catalog.write_csv(entries, args.csv)
+    vids = sum(1 for e in entries if e["kind"] == "video")
+    print(f"Catalogo: {len(entries)} ficheros ({vids} videos) -> {args.json} ; {args.csv}")
     return 0

--- a/kjsync/diff.py
+++ b/kjsync/diff.py
@@ -1,0 +1,86 @@
+"""Diff PURO de manifiestos: clasifica lecciones en nuevo/cambiado/renombrado/borrado."""
+from kjsync import model
+from kjsync.extract import norm
+
+
+def _index(rows):
+    by_pid = {}
+    by_title = {}
+    for r in rows:
+        if r["post_id"]:
+            by_pid[r["post_id"]] = r
+        by_title.setdefault((norm(r["course_title"]), norm(r["title"])), r)
+    return by_pid, by_title
+
+
+def _ref(r, **extra):
+    ref = {
+        "course_slug": r["course_slug"],
+        "module_title": r["module_title"],
+        "title": r["title"],
+        "url": r["url"],
+        "post_id": r["post_id"],
+    }
+    ref.update(extra)
+    return ref
+
+
+def _course_bucket(courses, slug, title):
+    if slug not in courses:
+        courses[slug] = {"title": title, "new": [], "changed": [],
+                         "renamed": [], "removed": [], "unchanged": 0}
+    return courses[slug]
+
+
+def diff_manifests(old, new):
+    old_rows = list(model.iter_lessons(old))
+    new_rows = list(model.iter_lessons(new))
+    old_by_pid, old_by_title = _index(old_rows)
+
+    courses = {}
+    matched_old_keys = set()
+
+    for r in new_rows:
+        bucket = _course_bucket(courses, r["course_slug"], r["course_title"])
+        match = None
+        if r["post_id"] and r["post_id"] in old_by_pid:
+            match = old_by_pid[r["post_id"]]
+        else:
+            match = old_by_title.get((norm(r["course_title"]), norm(r["title"])))
+        if match is None:
+            bucket["new"].append(_ref(r))
+            continue
+        # marcar el old emparejado
+        matched_old_keys.add(match["post_id"] or ("title", match["course_slug"], norm(match["title"])))
+        # renombrado y cambiado son independientes: una leccion puede ser ambos.
+        is_renamed = bool(
+            r["post_id"] and match["post_id"] == r["post_id"]
+            and norm(match["title"]) != norm(r["title"])
+        )
+        is_changed = bool(
+            r["fingerprint"] and match["fingerprint"]
+            and r["fingerprint"] != match["fingerprint"]
+        )
+        if is_renamed:
+            bucket["renamed"].append(_ref(r, old_title=match["title"]))
+        if is_changed:
+            bucket["changed"].append(_ref(r))
+        if not is_renamed and not is_changed:
+            bucket["unchanged"] += 1
+
+    # borrados: lecciones de old con post_id no emparejadas
+    for r in old_rows:
+        if not r["post_id"]:
+            continue
+        if r["post_id"] in matched_old_keys:
+            continue
+        bucket = _course_bucket(courses, r["course_slug"], r["course_title"])
+        bucket["removed"].append(_ref(r))
+
+    totals = {"new": 0, "changed": 0, "renamed": 0, "removed": 0, "lessons": len(new_rows)}
+    for b in courses.values():
+        totals["new"] += len(b["new"])
+        totals["changed"] += len(b["changed"])
+        totals["renamed"] += len(b["renamed"])
+        totals["removed"] += len(b["removed"])
+    return {"courses": courses, "totals": totals}

--- a/kjsync/download.py
+++ b/kjsync/download.py
@@ -1,0 +1,91 @@
+"""Descarga de los assets de una leccion a un directorio (reusa parsers puros)."""
+import os
+import re
+import time
+import requests
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from kjsync import extract
+
+_HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def _safe(name, maxlen=200):
+    return "".join(c if c.isalnum() or c in " ._-" else "_" for c in name)[:maxlen].strip()
+
+
+def wistia_mp4_url(wistia_id, referer):
+    api = f"https://fast.wistia.net/embed/medias/{wistia_id}.json"
+    resp = requests.get(api, headers={"Referer": referer, "User-Agent": "Mozilla/5.0"}, timeout=60)
+    if resp.status_code != 200:
+        return None
+    assets = resp.json().get("media", {}).get("assets", [])
+    mp4s = [a for a in assets if (a.get("type") == "original" or a.get("container") == "mp4")
+            and a.get("type") != "still_image"]
+    if not mp4s:
+        return None
+    mp4s.sort(key=lambda x: x.get("size", 0), reverse=True)
+    url = mp4s[0].get("url", "")
+    return url.replace(".bin", ".mp4") if url.endswith(".bin") else url
+
+
+def download_file(url, dest_path, timeout=60, retries=3):
+    for attempt in range(retries):
+        try:
+            with requests.get(url, stream=True, headers=_HEADERS, timeout=timeout) as r:
+                r.raise_for_status()
+                with open(dest_path, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+            if os.path.getsize(dest_path) > 0:
+                return True
+        except Exception:
+            time.sleep(3)
+    return False
+
+
+def download_lesson(driver, lesson, dest_dir, timeout=60):
+    os.makedirs(dest_dir, exist_ok=True)
+    base = _safe(f"{lesson['order']:02d} - {lesson['title']}")
+    status = {"video": "Failed", "materials": "None", "description": "None"}
+
+    driver.get(lesson["url"])
+    WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+    time.sleep(2)
+    page = driver.page_source
+
+    # Descripcion
+    if extract.has_description(page):
+        try:
+            from bs4 import BeautifulSoup
+            text = BeautifulSoup(page, "html.parser").select_one("div.kjb-rte").get_text("\n", strip=True)
+            with open(os.path.join(dest_dir, "description.txt"), "w", encoding="utf-8") as f:
+                f.write(text)
+            status["description"] = "Success"
+        except Exception:
+            status["description"] = "Failed"
+
+    # Video (Wistia)
+    wid = extract.extract_wistia_id(page)
+    if wid:
+        url = wistia_mp4_url(wid, lesson["url"])
+        if url and download_file(url, os.path.join(dest_dir, f"{base}.mp4"), timeout=timeout):
+            status["video"] = "Success"
+    else:
+        status["video"] = "None"
+
+    # Materiales
+    mats = extract.parse_materials(page)
+    if mats:
+        ok = True
+        for m in mats:
+            ext = os.path.splitext(m["url"].split("?")[0])[1] or ".bin"
+            path = os.path.join(dest_dir, _safe(m["name"]) + ext)
+            if not download_file(m["url"], path, timeout=timeout):
+                ok = False
+        status["materials"] = "Success" if ok else "Failed"
+
+    return status

--- a/kjsync/extract.py
+++ b/kjsync/extract.py
@@ -1,0 +1,123 @@
+"""Parsers PUROS (sin red, sin Selenium) para identidad y contenido de Kajabi."""
+import re
+
+from bs4 import BeautifulSoup
+
+
+def norm(s):
+    """Normaliza un titulo para comparaciones tolerantes."""
+    s = re.sub(r"^\s*\d+\s*[-.]\s*", "", s or "")
+    s = "".join(c if c.isalnum() or c.isspace() else " " for c in s)
+    return re.sub(r"\s+", " ", s).strip().lower()
+
+
+def extract_post_id(href):
+    """Extrae el ID de post estable de una URL de leccion de Kajabi."""
+    if not href:
+        return None
+    m = re.search(r"/posts/([A-Za-z0-9]+)", href)
+    if m:
+        return m.group(1)
+    m = re.search(r"post[_-]?id=([A-Za-z0-9]+)", href)
+    if m:
+        return m.group(1)
+    tail = [seg for seg in href.split("?")[0].split("/") if seg]
+    return tail[-1] if tail else None
+
+
+def extract_slug(url):
+    """Extrae el slug de producto (curso) de una URL de Kajabi."""
+    if not url:
+        return None
+    m = re.search(r"/products/([^/?#]+)", url)
+    return m.group(1) if m else None
+
+
+def extract_category_id(data_target):
+    """Devuelve el id de categoria (modulo) o None si es una cabecera fantasma."""
+    if not data_target:
+        return None
+    cid = data_target.lstrip("#").strip()
+    if not cid or cid == "sidebar-modal":
+        return None
+    return cid
+
+
+def parse_course_outline(page_source):
+    """Parsea el indice de un curso (modulos + lecciones) de forma pura."""
+    soup = BeautifulSoup(page_source, "html.parser")
+    modules = []
+    seen_pids = set()
+    order = 0
+    for header in soup.select("h3.product-outline-category"):
+        cat_id = extract_category_id(header.get("data-target"))
+        if not cat_id:
+            continue
+        container = soup.find(id=cat_id)
+        if container is None:
+            continue
+        link_nodes = container.select("a.product-outline-post")
+        if not link_nodes:
+            continue
+        title_node = header.select_one("div.media-body a") or header.select_one("div.media-body")
+        mtitle = title_node.get_text(strip=True) if title_node else header.get_text(strip=True).split("\n")[0]
+        lessons = []
+        for link in link_nodes:
+            href = link.get("href")
+            body = link.select_one("div.media-body")
+            ltitle = (body.get_text(strip=True) if body else link.get_text(strip=True))
+            if not href or not ltitle:
+                continue
+            pid = extract_post_id(href)
+            key = pid or href
+            if key in seen_pids:
+                continue
+            seen_pids.add(key)
+            lessons.append({"post_id": pid, "title": ltitle, "order": len(lessons) + 1, "url": href})
+        if not lessons:
+            continue
+        order += 1
+        modules.append({"category_id": cat_id, "title": mtitle, "order": order, "lessons": lessons})
+    return modules
+
+
+_WISTIA_PATTERNS = (
+    r"wistia_async_([a-z0-9]+)",
+    r"wistia\.com/medias/([a-z0-9]+)",
+    r"embed/medias/([a-z0-9]+)\.",
+)
+
+
+def extract_wistia_id(page_source):
+    for pat in _WISTIA_PATTERNS:
+        m = re.search(pat, page_source or "")
+        if m:
+            return m.group(1)
+    return None
+
+
+def parse_materials(page_source):
+    soup = BeautifulSoup(page_source or "", "html.parser")
+    items = []
+    for section in soup.select("section.sage-sortable__item--card"):
+        title_node = section.select_one("h1.sage-sortable__item-title")
+        link = section.select_one("a.sage-btn--icon-only-download")
+        if not title_node or not link or not link.get("href"):
+            continue
+        items.append({"name": title_node.get_text(strip=True), "url": link.get("href")})
+    items.sort(key=lambda x: x["name"])
+    return items
+
+
+def has_description(page_source):
+    soup = BeautifulSoup(page_source or "", "html.parser")
+    node = soup.select_one("div.kjb-rte")
+    return bool(node and node.get_text(strip=True))
+
+
+def lesson_fingerprint(page_source):
+    return {
+        "wistia_id": extract_wistia_id(page_source),
+        "materials": [m["name"] for m in parse_materials(page_source)],
+        "has_description": has_description(page_source),
+    }

--- a/kjsync/model.py
+++ b/kjsync/model.py
@@ -56,7 +56,8 @@ def save_manifest(manifest, path):
 
 
 def load_manifest(path):
-    if not os.path.exists(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
         return None
-    with open(path, encoding="utf-8") as f:
-        return json.load(f)

--- a/kjsync/model.py
+++ b/kjsync/model.py
@@ -1,0 +1,62 @@
+"""Esquema del manifiesto de sincronizacion y E/S atomica."""
+import json
+import os
+
+
+def new_manifest(scanned_at):
+    return {"scanned_at": scanned_at, "courses": {}}
+
+
+def add_course(manifest, slug, title, url):
+    course = {"title": title, "url": url, "modules": {}}
+    manifest["courses"][slug] = course
+    return course
+
+
+def set_module(course, category_id, title, order):
+    module = {"title": title, "order": order, "lessons": {}}
+    course["modules"][category_id] = module
+    return module
+
+
+def set_lesson(module, post_id, title, order, url, fingerprint=None):
+    key = post_id if post_id else f"_pos{order}"
+    module["lessons"][key] = {
+        "post_id": post_id,
+        "title": title,
+        "order": order,
+        "url": url,
+        "fingerprint": fingerprint,
+    }
+
+
+def iter_lessons(manifest):
+    rows = []
+    for slug, course in manifest.get("courses", {}).items():
+        for module in course.get("modules", {}).values():
+            for lesson in module.get("lessons", {}).values():
+                rows.append({
+                    "course_slug": slug,
+                    "course_title": course.get("title", ""),
+                    "module_title": module.get("title", ""),
+                    "post_id": lesson.get("post_id"),
+                    "title": lesson.get("title", ""),
+                    "order": lesson.get("order"),
+                    "url": lesson.get("url", ""),
+                    "fingerprint": lesson.get("fingerprint"),
+                })
+    return rows
+
+
+def save_manifest(manifest, path):
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+def load_manifest(path):
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)

--- a/kjsync/report.py
+++ b/kjsync/report.py
@@ -1,0 +1,40 @@
+"""Render del resultado del diff a markdown."""
+
+
+def _section(lines, label, refs):
+    if not refs:
+        return
+    lines.append(f"- {label} ({len(refs)}):")
+    for r in refs:
+        extra = f"  (antes: {r['old_title']})" if r.get("old_title") else ""
+        lines.append(f"    - {r.get('module_title', '')} / {r['title']}{extra}")
+
+
+def render_report(diff_result, scanned_at, deep):
+    t = diff_result["totals"]
+    mode = "profundo (huellas de contenido)" if deep else "estructural (solo altas/bajas/renombrados)"
+    lines = [
+        "# Informe de sincronizacion",
+        "",
+        f"Escaneado: {scanned_at}",
+        f"Modo: {mode}",
+        "",
+        "## Resumen",
+        "",
+        f"- Lecciones en el sitio: {t['lessons']}",
+        f"- Nuevas: {t['new']}",
+        f"- Cambiadas: {t['changed']}",
+        f"- Renombradas: {t['renamed']}",
+        f"- Borradas (solo informe): {t['removed']}",
+        "",
+    ]
+    for slug, b in diff_result["courses"].items():
+        if not (b["new"] or b["changed"] or b["renamed"] or b["removed"]):
+            continue
+        lines.append(f"## {b['title']}  ({slug})")
+        _section(lines, "NUEVAS", b["new"])
+        _section(lines, "CAMBIADAS", b["changed"])
+        _section(lines, "RENOMBRADAS", b["renamed"])
+        _section(lines, "BORRADAS", b["removed"])
+        lines.append("")
+    return "\n".join(lines)

--- a/kjsync/scan.py
+++ b/kjsync/scan.py
@@ -1,0 +1,70 @@
+"""Escaneo de la biblioteca Kajabi a un manifiesto, reutilizando parsers puros."""
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from kjsync import model, extract
+
+
+def get_courses(driver, base_url):
+    base_url = base_url.rstrip("/")
+    driver.get(f"{base_url}/library")
+    time.sleep(5)
+    courses = []
+    for card in driver.find_elements(By.CSS_SELECTOR, "div.product"):
+        try:
+            title = card.find_element(By.CSS_SELECTOR, "h4.product__title").text.strip()
+        except Exception:
+            title = card.text.strip().split("\n")[0]
+        try:
+            url = card.find_element(By.CSS_SELECTOR, "a[href*='/products/']").get_attribute("href")
+        except Exception:
+            continue
+        if "/communities/" in url:
+            continue
+        slug = extract.extract_slug(url)
+        if not slug:
+            continue
+        courses.append({"slug": slug, "title": title, "url": url})
+    return courses
+
+
+def scan_library(driver, base_url, scanned_at, course_filter=None, deep=False, progress=print):
+    manifest = model.new_manifest(scanned_at)
+    courses = get_courses(driver, base_url)
+    progress(f"Biblioteca: {len(courses)} cursos")
+    if course_filter:
+        terms = [t.strip().lower() for t in course_filter if t.strip()]
+        courses = [c for c in courses if any(t in c["slug"].lower() or t in c["title"].lower() for t in terms)]
+        progress(f"Filtrados a {len(courses)} curso(s)")
+
+    for c in courses:
+        progress(f"Escaneando: {c['title']} ({c['slug']})")
+        driver.get(c["url"])
+        WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+        time.sleep(4)
+        course_obj = model.add_course(manifest, c["slug"], c["title"], c["url"])
+        modules = extract.parse_course_outline(driver.page_source)
+        if not modules:
+            progress(f"  AVISO: sin modulos en {c['slug']} (selectores?)")
+            continue
+        for mod in modules:
+            module_obj = model.set_module(course_obj, mod["category_id"], mod["title"], mod["order"])
+            for les in mod["lessons"]:
+                url = les["url"]
+                if url and url.startswith("/"):
+                    url = base_url.rstrip("/") + url
+                fp = None
+                if deep and url:
+                    try:
+                        driver.get(url)
+                        WebDriverWait(driver, 30).until(
+                            EC.presence_of_element_located((By.TAG_NAME, "body")))
+                        time.sleep(2)
+                        fp = extract.lesson_fingerprint(driver.page_source)
+                    except Exception as e:
+                        progress(f"    AVISO: huella fallida en {les['title']}: {e}")
+                model.set_lesson(module_obj, les["post_id"], les["title"],
+                                 les["order"], url, fp)
+    return manifest

--- a/kjsync/seed.py
+++ b/kjsync/seed.py
@@ -1,0 +1,26 @@
+"""Construye un manifiesto base aproximado desde download_log.csv (sin post_id)."""
+import csv
+from kjsync import model, extract
+
+
+def seed_manifest_from_csv(csv_path, scanned_at=""):
+    manifest = model.new_manifest(scanned_at)
+    course_objs = {}
+    module_objs = {}
+    with open(csv_path, encoding="utf-8") as f:
+        for order, row in enumerate(csv.DictReader(f), start=1):
+            course_title = row.get("Course", "").strip()
+            module_title = row.get("Module", "").strip()
+            lesson_title = row.get("Lesson", "").strip()
+            if not course_title or not lesson_title:
+                continue
+            slug = extract.norm(course_title) or course_title
+            if slug not in course_objs:
+                course_objs[slug] = model.add_course(manifest, slug, course_title, "")
+            ckey = (slug, module_title)
+            if ckey not in module_objs:
+                cat_id = f"seed-{extract.norm(module_title)}"
+                module_objs[ckey] = model.set_module(
+                    course_objs[slug], cat_id, module_title, len(module_objs) + 1)
+            model.set_lesson(module_objs[ckey], None, lesson_title, order, "")
+    return manifest

--- a/kjsync/transcode.py
+++ b/kjsync/transcode.py
@@ -1,0 +1,236 @@
+"""Transcodificacion generica a HEVC via ffmpeg (agnostica al curso)."""
+import os
+import re
+import shutil
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+
+VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"}
+
+_FALLBACK_ORDER = ["hevc_nvenc", "hevc_qsv", "hevc_amf", "libx265"]
+_ALIASES = {"nvenc": "hevc_nvenc", "qsv": "hevc_qsv", "amf": "hevc_amf",
+            "libx265": "libx265", "x265": "libx265", "auto": "auto"}
+
+
+def _alias(short):
+    return _ALIASES.get((short or "auto"), short)
+
+
+def parse_hevc_encoders(text):
+    """Extrae encoders HEVC de la salida de 'ffmpeg -encoders'."""
+    found = []
+    for line in (text or "").splitlines():
+        m = re.match(r"\s+(\S{6})\s+(\S+)", line)
+        if not m or m.group(1)[0] != "V":
+            continue
+        name = m.group(2)
+        if name == "libx265" or name.startswith("hevc_"):
+            found.append(name)
+    return found
+
+
+def choose_encoder(preferred, available):
+    """'auto' elige el mejor hardware disponible y cae a libx265; un encoder
+    concreto se usa si esta, si no cae por el orden de fallback. None si nada."""
+    available = list(available or [])
+    pref = _alias(preferred or "auto")
+    if pref != "auto" and pref in available:
+        return pref
+    for enc in _FALLBACK_ORDER:
+        if enc in available:
+            return enc
+    return None
+
+
+def quality_args(encoder, crf, cq, preset):
+    if encoder == "libx265":
+        return ["-c:v", "libx265", "-preset", preset or "medium", "-crf", str(crf), "-tag:v", "hvc1"]
+    if encoder == "hevc_nvenc":
+        return ["-c:v", "hevc_nvenc", "-preset", preset or "p5", "-rc", "vbr", "-cq", str(cq), "-tag:v", "hvc1"]
+    if encoder == "hevc_qsv":
+        return ["-c:v", "hevc_qsv", "-global_quality", str(cq), "-tag:v", "hvc1"]
+    if encoder == "hevc_amf":
+        return ["-c:v", "hevc_amf", "-quality", "balanced", "-qp_i", str(cq), "-qp_p", str(cq), "-tag:v", "hvc1"]
+    return ["-c:v", encoder, "-tag:v", "hvc1"]
+
+
+def build_ffmpeg_cmd(src, dst, encoder, crf=23, cq=28, preset=None, metadata_args=None):
+    cmd = ["ffmpeg", "-y", "-hide_banner", "-i", src]
+    cmd += quality_args(encoder, crf, cq, preset)
+    cmd += ["-c:a", "copy"]
+    if metadata_args:
+        cmd += list(metadata_args)
+    cmd += [dst]
+    return cmd
+
+
+def output_name(src_name, tag):
+    stem, ext = os.path.splitext(src_name)
+    return f"{stem} [{tag}]{ext}"
+
+
+def already_transcoded(src_name, tag):
+    return f"[{tag}]" in src_name or f"[{tag}_" in src_name
+
+
+def parse_path_metadata(rel_path):
+    parts = [p for p in re.split(r"[\\/]+", rel_path) if p]
+    course = parts[0] if len(parts) >= 1 else ""
+    block = parts[1] if len(parts) >= 3 else ""
+    fname = os.path.splitext(parts[-1])[0] if parts else ""
+    m = re.match(r"^\s*(\d+)\s*-\s*(.+)$", fname)
+    if m:
+        track, title = m.group(1), m.group(2).strip()
+    else:
+        track, title = "", fname
+    return {"course": course, "block": block, "track": track, "title": title}
+
+
+def build_metadata_args(meta):
+    args = []
+    if meta.get("title"):
+        args += ["-metadata", f"title={meta['title']}"]
+    if meta.get("course"):
+        args += ["-metadata", f"album={meta['course']}"]
+    if meta.get("block"):
+        args += ["-metadata", f"album_artist={meta['block']}"]
+    if meta.get("track"):
+        args += ["-metadata", f"track={meta['track']}"]
+    return args
+
+
+def plan_tree(rel_files, video_exts, tag):
+    plan = {"transcode": [], "copy": [], "skip": []}
+    for rel in rel_files:
+        ext = os.path.splitext(rel)[1].lower()
+        name = os.path.basename(rel)
+        if ext in video_exts:
+            if already_transcoded(name, tag):
+                plan["skip"].append(rel)
+            else:
+                plan["transcode"].append(rel)
+        else:
+            plan["copy"].append(rel)
+    return plan
+
+
+def is_ffmpeg_available():
+    return shutil.which("ffmpeg") is not None
+
+
+def detect_hevc_encoders():
+    if not is_ffmpeg_available():
+        return []
+    try:
+        out = subprocess.run(["ffmpeg", "-hide_banner", "-encoders"],
+                             capture_output=True, text=True, timeout=30)
+        return parse_hevc_encoders(out.stdout)
+    except Exception:
+        return []
+
+
+def probe_height(path):
+    if shutil.which("ffprobe") is None:
+        return None
+    try:
+        out = subprocess.run(["ffprobe", "-v", "error", "-select_streams", "v:0",
+                              "-show_entries", "stream=height", "-of", "csv=p=0", path],
+                             capture_output=True, text=True, timeout=30)
+        line = out.stdout.strip().splitlines()[0]
+        return int(line)
+    except Exception:
+        return None
+
+
+def transcode_file(src, dst, cmd):
+    os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode == 0 and os.path.exists(dst) and os.path.getsize(dst) > 0:
+            return True
+        if os.path.exists(dst):
+            os.remove(dst)
+        return False
+    except Exception:
+        return False
+
+
+def transcode_tree(input_root, output_root, encoder="auto", crf=23, cq=28, preset=None,
+                   tag="h265", res_tag=False, copy_nonvideo=True, embed_metadata=False,
+                   replace=False, jobs=1, dry_run=False, progress=print):
+    if not is_ffmpeg_available():
+        progress("ERROR: ffmpeg no encontrado en PATH.")
+        return {"error": "no-ffmpeg"}
+    available = detect_hevc_encoders()
+    enc = choose_encoder(encoder, available)
+    if enc is None:
+        progress("ERROR: ningun encoder HEVC disponible.")
+        return {"error": "no-encoder"}
+    if _alias(encoder) != "auto" and enc != _alias(encoder):
+        progress(f"AVISO: encoder '{encoder}' no disponible; usando '{enc}'.")
+    progress(f"Encoder: {enc}")
+
+    rel_files = []
+    for dirpath, _dirs, files in os.walk(input_root):
+        for f in files:
+            rel_files.append(os.path.relpath(os.path.join(dirpath, f), input_root))
+    plan = plan_tree(rel_files, VIDEO_EXTS, tag)
+    progress(f"Plan: {len(plan['transcode'])} transcode, {len(plan['copy'])} copy, {len(plan['skip'])} skip")
+
+    summary = {"encoder": enc, "transcoded": 0, "copied": 0,
+               "skipped": len(plan["skip"]), "failed": []}
+
+    if dry_run:
+        for rel in plan["transcode"]:
+            progress(f"  [T] {rel}")
+        if copy_nonvideo:
+            for rel in plan["copy"]:
+                progress(f"  [C] {rel}")
+        summary["dry_run"] = True
+        return summary
+
+    if copy_nonvideo:
+        for rel in plan["copy"]:
+            dst = os.path.join(output_root, rel)
+            os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+            if not os.path.exists(dst):
+                shutil.copy2(os.path.join(input_root, rel), dst)
+            summary["copied"] += 1
+
+    def _do(rel):
+        src = os.path.join(input_root, rel)
+        local_tag = tag
+        if res_tag:
+            h = probe_height(src)
+            if h:
+                local_tag = f"{tag}_{h}p"
+        dst_name = output_name(os.path.basename(rel), local_tag)
+        dst = os.path.join(output_root, os.path.dirname(rel), dst_name)
+        if os.path.exists(dst) and os.path.getsize(dst) > 0:
+            return ("skip", rel)
+        meta_args = build_metadata_args(parse_path_metadata(rel)) if embed_metadata else None
+        cmd = build_ffmpeg_cmd(src, dst, enc, crf=crf, cq=cq, preset=preset, metadata_args=meta_args)
+        ok = transcode_file(src, dst, cmd)
+        if ok and replace:
+            try:
+                os.remove(src)
+            except OSError:
+                pass
+        return ("ok" if ok else "fail", rel)
+
+    if jobs > 1:
+        with ThreadPoolExecutor(max_workers=jobs) as ex:
+            results = list(ex.map(_do, plan["transcode"]))
+    else:
+        results = [_do(rel) for rel in plan["transcode"]]
+
+    for status, rel in results:
+        if status == "ok":
+            summary["transcoded"] += 1
+            progress(f"  OK {rel}")
+        elif status == "skip":
+            summary["skipped"] += 1
+        else:
+            summary["failed"].append(rel)
+            progress(f"  FALLO {rel}")
+    return summary

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Dev/test dependencies
+pytest>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,23 @@
+# Kajabi Course Downloader Dependencies
+
+# HTTP requests
+requests>=2.31.0
+
+# Environment variables management
+python-dotenv>=1.0.0
+
+# Web automation and scraping
+selenium>=4.16.0
+webdriver-manager>=4.0.1
+
+# Progress visualization
+tqdm>=4.66.1
+
+# For handling the Chrome browser
+chromedriver-autoinstaller>=0.6.2
+
+# For handling retries and timeouts
+urllib3>=2.0.7
+
+# HTML parsing (sync engine)
+beautifulsoup4>=4.12.0

--- a/sync_dryrun.py
+++ b/sync_dryrun.py
@@ -1,0 +1,308 @@
+"""
+Dry-run de solo lectura para validar la deteccion de delta (nuevo/cambiado/borrado).
+
+NO descarga nada. NO mueve nada. Solo hace login, recorre la estructura del sitio
+(cursos -> modulos -> lecciones), extrae la identidad estable (slug / category-id /
+post-id) y escribe:
+  - scan_manifest_dryrun.json : estado actual escaneado
+  - sync_report_dryrun.md      : informe legible (incluye comparacion aproximada
+                                 contra download_log.csv para marcar lo "probablemente nuevo")
+
+Uso:
+  uv run sync_dryrun.py --courses-only            # smoke test minimo: solo lista cursos
+  uv run sync_dryrun.py --course piano-basico     # escanea un curso (substring del slug/titulo)
+  uv run sync_dryrun.py                            # escanea todos los cursos (estructural)
+
+Flags:
+  --course <txt>   : filtra cursos cuyo slug o titulo contenga <txt> (repetible via coma)
+  --courses-only   : no entra en los cursos, solo enumera la biblioteca
+  --limit <n>      : limita el numero de cursos a escanear
+  --headless       : Chrome sin ventana (no recomendado en la primera corrida)
+"""
+
+import os
+import re
+import sys
+import csv
+import json
+import time
+import argparse
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoSuchElementException
+from webdriver_manager.chrome import ChromeDriverManager
+
+if sys.platform == "win32":
+    import codecs
+    sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+    sys.stderr = codecs.getwriter("utf-8")(sys.stderr.detach())
+
+load_dotenv()
+EMAIL = os.getenv("KAJABI_EMAIL")
+PASSWORD = os.getenv("KAJABI_PASSWORD")
+KAJABI_URL = (os.getenv("KAJABI_URL") or "").rstrip("/")
+
+MANIFEST_OUT = "scan_manifest_dryrun.json"
+REPORT_OUT = "sync_report_dryrun.md"
+LOG_FILE = "download_log.csv"
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def norm(s):
+    """Normalizacion suave para comparar titulos entre el sitio y el CSV."""
+    s = re.sub(r"^\s*\d+\s*[-.]\s*", "", s or "")          # quita prefijo numerico "01 - "
+    s = "".join(c if c.isalnum() or c.isspace() else " " for c in s)
+    return re.sub(r"\s+", " ", s).strip().lower()
+
+
+def extract_post_id(href):
+    """Intenta extraer un ID de post estable de la URL de la leccion."""
+    if not href:
+        return None
+    for pat in (r"/posts/([A-Za-z0-9]+)", r"/posts/([A-Za-z0-9]+)/?", r"post[_-]?id=([A-Za-z0-9]+)"):
+        m = re.search(pat, href)
+        if m:
+            return m.group(1)
+    # Fallback: ultimo segmento no vacio de la ruta
+    tail = [seg for seg in href.split("?")[0].split("/") if seg]
+    return tail[-1] if tail else None
+
+
+def extract_category_id(data_target, fallback):
+    if data_target and data_target not in ("#", "#sidebar-modal"):
+        return data_target.lstrip("#")
+    return fallback
+
+
+def build_driver(headless):
+    options = Options()
+    if headless:
+        options.add_argument("--headless=new")
+    options.add_argument("--start-maximized")
+    options.add_experimental_option("prefs", {
+        "profile.default_content_setting_values.notifications": 2,
+    })
+    return webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+
+
+def login(driver):
+    log(f"Login en {KAJABI_URL}/login ...")
+    driver.get(f"{KAJABI_URL}/login")
+    WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "member_email"))).send_keys(EMAIL)
+    driver.find_element(By.ID, "member_password").send_keys(PASSWORD)
+    driver.find_element(By.XPATH, "//button[@type='submit']").click()
+    time.sleep(6)
+    url = driver.current_url
+    if any(k in url for k in ("library", "dashboard", "admin")) or "login" not in url:
+        log(f"  OK login -> {url}")
+        return True
+    log(f"  AVISO: la URL tras login es {url} (puede requerir 2FA/captcha; resuelvelo en la ventana)")
+    # Dar tiempo a resolver 2FA manualmente
+    time.sleep(20)
+    return "login" not in driver.current_url
+
+
+def get_courses(driver):
+    log("Abriendo biblioteca ...")
+    driver.get(f"{KAJABI_URL}/library")
+    time.sleep(5)
+    cards = driver.find_elements(By.CSS_SELECTOR, "div.product")
+    courses = []
+    for card in cards:
+        try:
+            title = card.find_element(By.CSS_SELECTOR, "h4.product__title").text.strip()
+        except NoSuchElementException:
+            title = card.text.strip().split("\n")[0]
+        try:
+            url = card.find_element(By.CSS_SELECTOR, "a[href*='/products/']").get_attribute("href")
+        except NoSuchElementException:
+            continue
+        if "/communities/" in url:
+            continue
+        slug_m = re.search(r"/products/([^/?#]+)", url)
+        courses.append({"title": title, "url": url, "slug": slug_m.group(1) if slug_m else url})
+    return courses
+
+
+def scan_course(driver, course):
+    log(f"\n== Curso: {course['title']}  ({course['slug']})")
+    driver.get(course["url"])
+    WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+    time.sleep(4)
+
+    headers = driver.find_elements(By.CSS_SELECTOR, "h3.product-outline-category")
+    if not headers:
+        log("  AVISO: no se encontraron modulos (h3.product-outline-category). Selectores pueden haber cambiado.")
+        with open(f"debug_outline_{course['slug']}.html", "w", encoding="utf-8") as f:
+            f.write(driver.page_source)
+        log(f"  HTML guardado en debug_outline_{course['slug']}.html para inspeccion.")
+        return {"title": course["title"], "url": course["url"], "modules": {}}
+
+    modules = {}
+    seen_pids = set()   # dedupe por curso: una leccion solo cuenta en su modulo real
+    mod_order = 0
+    for header in headers:
+        try:
+            try:
+                mtitle = header.find_element(By.CSS_SELECTOR, "div.media-body a").text.strip()
+            except NoSuchElementException:
+                mtitle = header.text.strip().split("\n")[0]
+            cat_id = extract_category_id(header.get_attribute("data-target"), None)
+            # Saltar cabecera fantasma: sin contenedor de categoria resoluble
+            # (su data-target es "#"/"#sidebar-modal"), que de usar fallback recogeria
+            # TODAS las lecciones del curso y duplicaria los totales.
+            if not cat_id:
+                continue
+            links = driver.find_elements(By.CSS_SELECTOR, f"div#{cat_id} a.product-outline-post")
+            if not links:
+                continue
+            lessons = {}
+            order = 0
+            for link in links:
+                href = link.get_attribute("href")
+                try:
+                    ltitle = link.find_element(By.CSS_SELECTOR, "div.media-body").text.strip()
+                except NoSuchElementException:
+                    ltitle = link.text.strip()
+                if not href or not ltitle:
+                    continue
+                pid = extract_post_id(href)
+                key = pid or href
+                if key in seen_pids:
+                    continue
+                seen_pids.add(key)
+                order += 1
+                lessons[pid or f"_pos{order}"] = {"title": ltitle, "order": order, "url": href, "post_id": pid}
+            if not lessons:
+                continue
+            mod_order += 1
+            modules[cat_id] = {"title": mtitle, "order": mod_order, "lessons": lessons}
+            log(f"  Modulo {mod_order:02d}: {mtitle}  ({len(lessons)} lecciones)")
+        except Exception as e:
+            log(f"  ERROR modulo: {e}")
+    return {"title": course["title"], "url": course["url"], "modules": modules}
+
+
+def load_known_from_csv():
+    """Devuelve {curso_norm: set(titulo_leccion_norm)} desde download_log.csv (baseline aproximado)."""
+    known = {}
+    if not os.path.exists(LOG_FILE):
+        return known
+    with open(LOG_FILE, "r", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            c = norm(row.get("Course", ""))
+            known.setdefault(c, set()).add(norm(row.get("Lesson", "")))
+    return known
+
+
+def write_report(manifest, known):
+    lines = ["# Informe dry-run de sincronizacion", "",
+             f"Escaneado: {manifest['scanned_at']}", ""]
+    total_lessons = 0
+    total_new = 0
+    no_pid_courses = []
+
+    for slug, c in manifest["courses"].items():
+        known_titles = known.get(norm(c["title"]), set())
+        course_new = []
+        course_total = 0
+        pid_ok = 0
+        pid_total = 0
+        for mod in c["modules"].values():
+            for pid, les in mod["lessons"].items():
+                course_total += 1
+                pid_total += 1
+                if les.get("post_id"):
+                    pid_ok += 1
+                if known_titles and norm(les["title"]) not in known_titles:
+                    course_new.append(f"{mod['title']} / {les['title']}")
+        total_lessons += course_total
+        total_new += len(course_new)
+        if pid_total and pid_ok == 0:
+            no_pid_courses.append(slug)
+
+        lines.append(f"## {c['title']}  ({slug})")
+        lines.append(f"- Modulos: {len(c['modules'])} | Lecciones: {course_total} | "
+                     f"post_id extraido: {pid_ok}/{pid_total}")
+        if not known_titles:
+            lines.append("- (sin baseline en CSV para este curso; no se puede marcar 'nuevo')")
+        elif course_new:
+            lines.append(f"- PROBABLEMENTE NUEVAS ({len(course_new)}):")
+            lines += [f"    - {x}" for x in course_new]
+        else:
+            lines.append("- Sin lecciones nuevas respecto al CSV.")
+        lines.append("")
+
+    summary = ["## Resumen", "",
+               f"- Cursos escaneados: {len(manifest['courses'])}",
+               f"- Lecciones totales: {total_lessons}",
+               f"- Probablemente nuevas (vs CSV): {total_new}"]
+    if no_pid_courses:
+        summary.append(f"- AVISO: sin post_id en: {', '.join(no_pid_courses)} "
+                       f"(revisar extract_post_id / formato de URL)")
+    summary.append("")
+    lines = lines[:3] + summary + lines[3:]
+
+    with open(REPORT_OUT, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    log(f"\nInforme escrito en {REPORT_OUT}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--course", action="append", default=[], help="substring de slug/titulo (repetible)")
+    ap.add_argument("--courses-only", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--headless", action="store_true")
+    args = ap.parse_args()
+
+    if not (EMAIL and PASSWORD and KAJABI_URL):
+        log("ERROR: faltan KAJABI_EMAIL / KAJABI_PASSWORD / KAJABI_URL en .env")
+        return 1
+
+    driver = build_driver(args.headless)
+    try:
+        if not login(driver):
+            log("ERROR: login fallido.")
+            return 1
+
+        courses = get_courses(driver)
+        log(f"\nCursos encontrados en la biblioteca: {len(courses)}")
+        for c in courses:
+            log(f"  - {c['title']}  ({c['slug']})")
+
+        if args.course:
+            filt = [t.strip().lower() for t in ",".join(args.course).split(",") if t.strip()]
+            courses = [c for c in courses if any(t in c["slug"].lower() or t in c["title"].lower() for t in filt)]
+            log(f"\nFiltrados a {len(courses)} curso(s) por {filt}")
+        if args.limit:
+            courses = courses[:args.limit]
+
+        manifest = {"scanned_at": datetime.now(timezone.utc).isoformat(), "courses": {}}
+        if not args.courses_only:
+            for c in courses:
+                manifest["courses"][c["slug"]] = scan_course(driver, c)
+
+        with open(MANIFEST_OUT, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
+        log(f"\nManifiesto escrito en {MANIFEST_OUT}")
+
+        if not args.courses_only:
+            write_report(manifest, load_known_from_csv())
+    finally:
+        driver.quit()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/download_log_sample.csv
+++ b/tests/fixtures/download_log_sample.csv
@@ -1,0 +1,4 @@
+Timestamp,Course,Module,Lesson,Description,Thumbnail,Video,Material
+2025-12-10 21:59:40,Armonia Basica,0. Bienvenido,01 - Bienvenidos,Success,Success,Success,None
+2025-12-10 22:01:39,Armonia Basica,0. Bienvenido,02 - Preguntas frecuentes,Success,Success,Success,None
+2025-12-10 22:05:45,Armonia Basica,1. Que es la armonia,01 - Escalas,Failed,Failed,Success,None

--- a/tests/fixtures/lesson_sample.html
+++ b/tests/fixtures/lesson_sample.html
@@ -1,0 +1,12 @@
+<!doctype html><html><body>
+  <div class="kjb-rte"><p>Descripcion de la leccion con texto.</p></div>
+  <div class="wistia_embed wistia_async_glxqbp7vs5"></div>
+  <section class="sage-sortable__item--card">
+    <h1 class="sage-sortable__item-title">Letra y acordes</h1>
+    <a class="sage-btn--icon-only-download" href="https://files.example.com/letra.pdf?sig=abc">descargar</a>
+  </section>
+  <section class="sage-sortable__item--card">
+    <h1 class="sage-sortable__item-title">Partitura</h1>
+    <a class="sage-btn--icon-only-download" href="https://files.example.com/part.pdf">descargar</a>
+  </section>
+</body></html>

--- a/tests/fixtures/outline_sample.html
+++ b/tests/fixtures/outline_sample.html
@@ -1,0 +1,23 @@
+<!doctype html><html><body>
+  <h3 class="product-outline-category" data-target="#">
+    <div class="media-body"><a>FANTASMA</a></div>
+  </h3>
+  <a class="product-outline-post" href="/products/curso/categories/10/posts/1001"><div class="media-body">01 - Intro</div></a>
+  <a class="product-outline-post" href="/products/curso/categories/10/posts/1002"><div class="media-body">02 - Escalas</div></a>
+  <a class="product-outline-post" href="/products/curso/categories/20/posts/2001"><div class="media-body">01 - Modos</div></a>
+
+  <h3 class="product-outline-category" data-target="#category-10">
+    <div class="media-body"><a>Bloque 1</a></div>
+  </h3>
+  <div id="category-10">
+    <a class="product-outline-post" href="/products/curso/categories/10/posts/1001"><div class="media-body">01 - Intro</div></a>
+    <a class="product-outline-post" href="/products/curso/categories/10/posts/1002"><div class="media-body">02 - Escalas</div></a>
+  </div>
+
+  <h3 class="product-outline-category" data-target="#category-20">
+    <div class="media-body"><a>Bloque 2</a></div>
+  </h3>
+  <div id="category-20">
+    <a class="product-outline-post" href="/products/curso/categories/20/posts/2001"><div class="media-body">01 - Modos</div></a>
+  </div>
+</body></html>

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,55 @@
+import os
+import json
+
+from kjsync import catalog
+
+
+def test_classify_kind():
+    assert catalog.classify_kind(".mp4") == "video"
+    assert catalog.classify_kind(".PDF") == "material"
+    assert catalog.classify_kind(".xyz") == "other"
+
+
+def test_catalog_entry():
+    e = catalog.catalog_entry("Curso X/Bloque 1/03 - La leccion.mp4", 12345)
+    assert e["course"] == "Curso X"
+    assert e["block"] == "Bloque 1"
+    assert e["track"] == "03"
+    assert e["title"] == "La leccion"
+    assert e["ext"] == ".mp4"
+    assert e["kind"] == "video"
+    assert e["size"] == 12345
+    assert e["relative_path"] == "Curso X/Bloque 1/03 - La leccion.mp4"
+
+
+def test_build_and_write(tmp_path):
+    root = tmp_path / "lib"
+    d = root / "Curso A" / "Bloque 1"
+    d.mkdir(parents=True)
+    (d / "01 - intro.mp4").write_bytes(b"x" * 10)
+    (d / "02 - notas.pdf").write_bytes(b"y" * 5)
+    entries = catalog.build_catalog(str(root))
+    assert len(entries) == 2
+    kinds = {e["title"]: e["kind"] for e in entries}
+    assert kinds["intro"] == "video"
+    assert kinds["notas"] == "material"
+
+    jpath = str(tmp_path / "cat.json")
+    cpath = str(tmp_path / "cat.csv")
+    catalog.write_json(entries, jpath)
+    catalog.write_csv(entries, cpath)
+    data = json.loads(open(jpath, encoding="utf-8").read())
+    assert data["generated_count"] == 2
+    assert len(data["entries"]) == 2
+    csv_text = open(cpath, encoding="utf-8").read()
+    assert "relative_path" in csv_text.splitlines()[0]
+    assert "intro" in csv_text
+
+
+def test_build_catalog_uses_forward_slashes(tmp_path):
+    d = tmp_path / "lib" / "Curso" / "Bloque"
+    d.mkdir(parents=True)
+    (d / "01 - v.mp4").write_bytes(b"x")
+    entries = catalog.build_catalog(str(tmp_path / "lib"))
+    assert all("\\" not in e["relative_path"] for e in entries)
+    assert entries[0]["relative_path"] == "Curso/Bloque/01 - v.mp4"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,99 @@
+from kjsync import diff, model
+
+
+def mk(slug, title, lessons):
+    """lessons: list of (post_id, title, fingerprint)"""
+    m = model.new_manifest("t")
+    c = model.add_course(m, slug, title, "")
+    mod = model.set_module(c, "cat-1", "Bloque 1", 1)
+    for i, (pid, ltitle, fp) in enumerate(lessons, start=1):
+        model.set_lesson(mod, pid, ltitle, i, f"/posts/{pid}" if pid else "", fp)
+    return m
+
+
+def test_new_lesson_detected():
+    old = mk("curso", "Curso", [("1", "Intro", None)])
+    new = mk("curso", "Curso", [("1", "Intro", None), ("2", "Escalas", None)])
+    d = diff.diff_manifests(old, new)
+    assert [r["title"] for r in d["courses"]["curso"]["new"]] == ["Escalas"]
+    assert d["totals"]["new"] == 1
+
+
+def test_removed_lesson_detected():
+    old = mk("curso", "Curso", [("1", "Intro", None), ("2", "Escalas", None)])
+    new = mk("curso", "Curso", [("1", "Intro", None)])
+    d = diff.diff_manifests(old, new)
+    assert [r["title"] for r in d["courses"]["curso"]["removed"]] == ["Escalas"]
+    assert d["totals"]["removed"] == 1
+
+
+def test_renamed_lesson_same_post_id():
+    old = mk("curso", "Curso", [("1", "Intro", None)])
+    new = mk("curso", "Curso", [("1", "Introduccion", None)])
+    d = diff.diff_manifests(old, new)
+    assert d["courses"]["curso"]["renamed"][0]["old_title"] == "Intro"
+    assert d["totals"]["renamed"] == 1
+    assert d["totals"]["new"] == 0
+
+
+def test_changed_fingerprint():
+    fp_a = {"wistia_id": "aaa", "materials": [], "has_description": True}
+    fp_b = {"wistia_id": "bbb", "materials": [], "has_description": True}
+    old = mk("curso", "Curso", [("1", "Intro", fp_a)])
+    new = mk("curso", "Curso", [("1", "Intro", fp_b)])
+    d = diff.diff_manifests(old, new)
+    assert d["totals"]["changed"] == 1
+
+
+def test_no_change_when_fingerprint_missing_on_new():
+    fp_a = {"wistia_id": "aaa", "materials": [], "has_description": True}
+    old = mk("curso", "Curso", [("1", "Intro", fp_a)])
+    new = mk("curso", "Curso", [("1", "Intro", None)])  # estructural: sin huella
+    d = diff.diff_manifests(old, new)
+    assert d["totals"]["changed"] == 0
+    assert d["courses"]["curso"]["unchanged"] == 1
+
+
+def test_positional_insert_no_false_new():
+    # Insertar al principio NO debe marcar las demas como nuevas (emparejan por post_id)
+    old = mk("curso", "Curso", [("1", "A", None), ("2", "B", None)])
+    new = mk("curso", "Curso", [("9", "Nueva", None), ("1", "A", None), ("2", "B", None)])
+    d = diff.diff_manifests(old, new)
+    assert [r["title"] for r in d["courses"]["curso"]["new"]] == ["Nueva"]
+    assert d["totals"]["new"] == 1
+
+
+def test_title_fallback_when_no_post_id():
+    # Semilla sin post_id empareja por titulo normalizado
+    old = mk("curso", "Curso", [(None, "01 - Intro", None)])
+    new = mk("curso", "Curso", [("1", "Intro", None)])
+    d = diff.diff_manifests(old, new)
+    assert d["totals"]["new"] == 0
+    assert d["courses"]["curso"]["unchanged"] == 1
+
+
+def test_renamed_and_changed_both_classified():
+    fp_a = {"wistia_id": "aaa", "materials": [], "has_description": True}
+    fp_b = {"wistia_id": "bbb", "materials": [], "has_description": True}
+    old = mk("curso", "Curso", [("1", "Intro", fp_a)])
+    new = mk("curso", "Curso", [("1", "Introduccion", fp_b)])
+    d = diff.diff_manifests(old, new)
+    assert d["totals"]["renamed"] == 1
+    assert d["totals"]["changed"] == 1
+    assert d["courses"]["curso"]["unchanged"] == 0
+
+
+def test_title_fallback_matches_across_differing_course_slugs():
+    # Seed baseline: course_slug derived from CSV title (norm), post_id=None.
+    old = model.new_manifest("t")
+    c_old = model.add_course(old, "demo course", "Demo Course!", "")
+    mo = model.set_module(c_old, "seed-x", "Bloque", 1)
+    model.set_lesson(mo, None, "01 - Intro Lesson", 1, "")
+    # Live scan: product slug differs, post_id present.
+    new = model.new_manifest("t")
+    c_new = model.add_course(new, "demo-course", "Demo Course!", "")
+    mn = model.set_module(c_new, "cat-1", "Bloque", 1)
+    model.set_lesson(mn, "1000001", "Intro Lesson", 1, "/posts/1000001")
+    d = diff.diff_manifests(old, new)
+    assert d["totals"]["new"] == 0
+    assert d["courses"]["demo-course"]["unchanged"] == 1

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,67 @@
+import os
+
+from kjsync import extract
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def _read_fixture(name):
+    with open(os.path.join(FIXTURES, name), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_norm_strips_prefix_and_lowercases():
+    assert extract.norm("01 - Las Septimas") == "las septimas"
+    assert extract.norm("12. Un Modo. Tres escalas.") == "un modo tres escalas"
+
+
+def test_extract_post_id_from_posts_url():
+    href = "https://school.example.com/products/demo-course/categories/123/posts/987654"
+    assert extract.extract_post_id(href) == "987654"
+
+
+def test_extract_post_id_fallback_last_segment():
+    assert extract.extract_post_id("https://x.com/a/b/cde?q=1") == "cde"
+    assert extract.extract_post_id(None) is None
+
+
+def test_extract_slug():
+    assert extract.extract_slug("https://school.example.com/products/sample-course") == "sample-course"
+    assert extract.extract_slug("https://school.example.com/products/sample-course/categories/1") == "sample-course"
+    assert extract.extract_slug(None) is None
+
+
+def test_extract_category_id_skips_phantoms():
+    assert extract.extract_category_id("#category-555") == "category-555"
+    assert extract.extract_category_id("#") is None
+    assert extract.extract_category_id("#sidebar-modal") is None
+    assert extract.extract_category_id(None) is None
+
+
+def test_parse_course_outline_skips_phantom_and_dedupes():
+    modules = extract.parse_course_outline(_read_fixture("outline_sample.html"))
+    # La cabecera fantasma (data-target="#") no debe producir modulo
+    assert [m["title"] for m in modules] == ["Bloque 1", "Bloque 2"]
+    assert modules[0]["category_id"] == "category-10"
+    assert [l["title"] for l in modules[0]["lessons"]] == ["01 - Intro", "02 - Escalas"]
+    assert modules[0]["lessons"][0]["post_id"] == "1001"
+    assert modules[1]["lessons"][0]["post_id"] == "2001"
+    # Total de lecciones sin duplicar = 3
+    total = sum(len(m["lessons"]) for m in modules)
+    assert total == 3
+
+
+def test_lesson_fingerprint_fields():
+    html = _read_fixture("lesson_sample.html")
+    assert extract.extract_wistia_id(html) == "glxqbp7vs5"
+    mats = extract.parse_materials(html)
+    assert [m["name"] for m in mats] == ["Letra y acordes", "Partitura"]
+    assert mats[0]["url"].startswith("https://files.example.com/letra.pdf")
+    assert extract.has_description(html) is True
+    fp = extract.lesson_fingerprint(html)
+    assert fp == {"wistia_id": "glxqbp7vs5", "materials": ["Letra y acordes", "Partitura"], "has_description": True}
+
+
+def test_lesson_fingerprint_empty():
+    fp = extract.lesson_fingerprint("<html><body></body></html>")
+    assert fp == {"wistia_id": None, "materials": [], "has_description": False}

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -65,3 +65,8 @@ def test_lesson_fingerprint_fields():
 def test_lesson_fingerprint_empty():
     fp = extract.lesson_fingerprint("<html><body></body></html>")
     assert fp == {"wistia_id": None, "materials": [], "has_description": False}
+
+
+def test_extract_wistia_id_alt_patterns():
+    assert extract.extract_wistia_id('<a href="https://wistia.com/medias/abc123">') == "abc123"
+    assert extract.extract_wistia_id('src=".../embed/medias/xyz789.m3u8"') == "xyz789"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,34 @@
+import os
+from kjsync import model
+
+
+def build_sample():
+    m = model.new_manifest("2026-06-30T00:00:00Z")
+    c = model.add_course(m, "curso", "Curso", "https://x/products/curso")
+    mod = model.set_module(c, "category-10", "Bloque 1", 1)
+    model.set_lesson(mod, "1001", "01 - Intro", 1, "https://x/posts/1001",
+                     {"wistia_id": "aaa", "materials": [], "has_description": True})
+    return m
+
+
+def test_iter_lessons_flattens():
+    rows = model.iter_lessons(build_sample())
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["course_slug"] == "curso"
+    assert r["module_title"] == "Bloque 1"
+    assert r["post_id"] == "1001"
+    assert r["fingerprint"]["wistia_id"] == "aaa"
+    assert r["order"] == 1
+
+
+def test_save_load_roundtrip(tmp_path):
+    path = os.path.join(tmp_path, "m.json")
+    m = build_sample()
+    model.save_manifest(m, path)
+    loaded = model.load_manifest(path)
+    assert loaded == m
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert model.load_manifest(os.path.join(tmp_path, "nope.json")) is None

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,26 @@
+from kjsync import report
+
+
+def sample_diff():
+    return {
+        "courses": {
+            "curso": {"title": "Curso", "unchanged": 5,
+                      "new": [{"module_title": "B1", "title": "Escalas", "post_id": "2", "url": "/posts/2"}],
+                      "changed": [], "renamed": [], "removed": []},
+        },
+        "totals": {"new": 1, "changed": 0, "renamed": 0, "removed": 0, "lessons": 6},
+    }
+
+
+def test_report_has_summary_and_sections():
+    md = report.render_report(sample_diff(), "2026-06-30T00:00:00Z", deep=False)
+    assert "# Informe de sincronizacion" in md
+    assert "Nuevas: 1" in md
+    assert "## Curso" in md
+    assert "Escalas" in md
+    assert "estructural" in md.lower()
+
+
+def test_report_deep_flag():
+    md = report.render_report(sample_diff(), "t", deep=True)
+    assert "profundo" in md.lower()

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,18 @@
+import os
+from kjsync import seed, model, extract
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def test_seed_builds_baseline_with_null_post_ids():
+    m = seed.seed_manifest_from_csv(os.path.join(FIXTURES, "download_log_sample.csv"))
+    rows = model.iter_lessons(m)
+    assert len(rows) == 3
+    assert all(r["post_id"] is None for r in rows)
+    titles = {extract.norm(r["title"]) for r in rows}
+    assert "bienvenidos" in titles
+    assert "escalas" in titles
+    # Un unico curso (Armonia Basica) con dos modulos
+    assert len(m["courses"]) == 1
+    course = next(iter(m["courses"].values()))
+    assert len(course["modules"]) == 2

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -1,0 +1,90 @@
+from kjsync import transcode
+
+ENCODERS_SAMPLE = """Encoders:
+ V..... = Video
+ ------
+ V....D libx264              libx264 H.264
+ V....D libx265              libx265 H.265 / HEVC (codec hevc)
+ V....D hevc_nvenc           NVIDIA NVENC hevc encoder (codec hevc)
+ V..... hevc_qsv             HEVC (Intel Quick Sync) (codec hevc)
+ A....D aac                  AAC
+"""
+
+
+def test_parse_hevc_encoders():
+    enc = transcode.parse_hevc_encoders(ENCODERS_SAMPLE)
+    assert "libx265" in enc
+    assert "hevc_nvenc" in enc
+    assert "hevc_qsv" in enc
+    assert "libx264" not in enc
+    assert "aac" not in enc
+
+
+def test_choose_encoder_auto_prefers_hardware():
+    assert transcode.choose_encoder("auto", ["libx265", "hevc_nvenc"]) == "hevc_nvenc"
+    assert transcode.choose_encoder("auto", ["libx265"]) == "libx265"
+    assert transcode.choose_encoder("auto", []) is None
+
+
+def test_choose_encoder_specific_and_fallback():
+    assert transcode.choose_encoder("nvenc", ["hevc_nvenc", "libx265"]) == "hevc_nvenc"
+    assert transcode.choose_encoder("libx265", ["libx265"]) == "libx265"
+    # pedido no disponible -> fallback al mejor disponible
+    assert transcode.choose_encoder("qsv", ["libx265"]) == "libx265"
+
+
+def test_quality_args_per_encoder():
+    assert transcode.quality_args("libx265", 23, 28, None)[:2] == ["-c:v", "libx265"]
+    assert "-crf" in transcode.quality_args("libx265", 23, 28, None)
+    nv = transcode.quality_args("hevc_nvenc", 23, 28, None)
+    assert nv[:2] == ["-c:v", "hevc_nvenc"]
+    assert "-cq" in nv
+
+
+def test_build_ffmpeg_cmd():
+    cmd = transcode.build_ffmpeg_cmd("in.mp4", "out.mp4", "libx265", crf=20)
+    assert cmd[0] == "ffmpeg" and "-i" in cmd and cmd[-1] == "out.mp4"
+    assert "in.mp4" in cmd
+    assert "-c:a" in cmd and "copy" in cmd
+    assert "20" in cmd  # crf value
+    cmd2 = transcode.build_ffmpeg_cmd("in.mp4", "out.mp4", "libx265", metadata_args=["-metadata", "title=X"])
+    assert "title=X" in cmd2
+
+
+def test_output_name_and_idempotency():
+    assert transcode.output_name("01 - Intro.mp4", "h265") == "01 - Intro [h265].mp4"
+    assert transcode.already_transcoded("01 - Intro [h265].mp4", "h265") is True
+    assert transcode.already_transcoded("01 - Intro.mp4", "h265") is False
+
+
+def test_parse_path_metadata():
+    meta = transcode.parse_path_metadata("Curso X/Bloque 1/03 - La leccion.mp4")
+    assert meta["course"] == "Curso X"
+    assert meta["block"] == "Bloque 1"
+    assert meta["track"] == "03"
+    assert meta["title"] == "La leccion"
+
+
+def test_build_metadata_args():
+    args = transcode.build_metadata_args({"course": "C", "block": "B", "track": "3", "title": "T"})
+    assert "-metadata" in args
+    assert "title=T" in args
+    assert "album=C" in args
+
+
+def test_plan_tree_classifies():
+    files = ["a/01 - v.mp4", "a/02 - v [h265].mp4", "a/doc.pdf"]
+    plan = transcode.plan_tree(files, transcode.VIDEO_EXTS, "h265")
+    assert plan["transcode"] == ["a/01 - v.mp4"]
+    assert plan["skip"] == ["a/02 - v [h265].mp4"]
+    assert plan["copy"] == ["a/doc.pdf"]
+
+
+def test_is_ffmpeg_available_returns_bool():
+    assert isinstance(transcode.is_ffmpeg_available(), bool)
+
+
+def test_already_transcoded_recognizes_res_tag():
+    assert transcode.already_transcoded("v [h265].mp4", "h265") is True
+    assert transcode.already_transcoded("v [h265_1080p].mp4", "h265") is True
+    assert transcode.already_transcoded("v.mp4", "h265") is False


### PR DESCRIPTION
@
Hi! Thanks for this tool. This PR contributes three optional, backward-compatible capabilities built on top of the existing downloader. Running `kajabi.py` with no subcommand keeps the original full-download behavior unchanged.

## 1. Incremental sync (`scan` / `diff` / `sync`)

Re-download only what changed on a Kajabi school since the last run.
- Stable per-lesson identity via the Kajabi `post_id` (survives reordering/renaming), plus a content fingerprint (Wistia id, materials, description) for change detection.
- `sync` scans the library into a manifest, diffs it against the previous manifest (or a baseline seeded from `download_log.csv` on first run), classifies lessons as new / changed / renamed / removed, writes a markdown report, and downloads only new + changed into a staging dir. Removed lessons are reported only, never deleted.
- Structural scan by default (fast); `--deep` captures content fingerprints. `--dry-run` previews without writing state; `--course` scopes to one course.

## 2. Transcode to HEVC (`transcode`, `sync --transcode`)

Re-encode downloaded videos to H.265/HEVC with ffmpeg to save space.
- Encoder auto-detection with fallback (nvenc > qsv > amf > libx265); `--encoder` overrides; graceful message if ffmpeg is missing.
- Non-video pass-through, idempotent skip, optional metadata embedding, optional parallel `--jobs`, `--dry-run`.

## 3. Catalog (`catalog`)

Write a JSON + CSV index of a downloaded tree (course, block, track, title, kind, size, path).

## Notes

- New code lives in a `kjsync/` package; selectors/paths are configurable via `config.ini`.
- Adds `beautifulsoup4` (sync HTML parsing) to requirements; ffmpeg is an optional external dependency only for `transcode`.
- 39 unit tests for the pure logic (`uv run pytest`); the Selenium/ffmpeg paths were verified end-to-end against a live school.

Happy to split this into smaller PRs or adjust anything if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@